### PR TITLE
feat(acr-to-acr-mi): error reporting, Catalog Lister role caveat, and docker pull output

### DIFF
--- a/demos/kubecon-eu-2026/acr-to-acr-mi/README.md
+++ b/demos/kubecon-eu-2026/acr-to-acr-mi/README.md
@@ -109,7 +109,7 @@ export UAMI_PRINCIPAL_ID=$(az identity show \
 
 ## Step 5 — Enable ABAC on the Source Registry
 
-The `Container Registry Repository Reader` role is an ABAC (Attribute-Based Access Control) role. ABAC must be enabled on the source registry before this role assignment takes effect.
+The `Container Registry Repository Reader` and `Container Registry Repository Catalog Lister` roles are ABAC (Attribute-Based Access Control) roles. ABAC must be enabled on the source registry before these role assignments take effect.
 
 ```bash
 az acr update \
@@ -151,6 +151,16 @@ SOURCE_REGISTRY_ID=$(az acr show \
 az role assignment create \
     --assignee $UAMI_PRINCIPAL_ID \
     --role "Container Registry Repository Reader" \
+    --scope $SOURCE_REGISTRY_ID \
+    --subscription $SUBSCRIPTION
+```
+
+Optionally, if clients also need to list all available tags on the source registry (not required for image pulls), assign the catalog lister role as well:
+
+```bash
+az role assignment create \
+    --assignee $UAMI_PRINCIPAL_ID \
+    --role "Container Registry Repository Catalog Lister" \
     --scope $SOURCE_REGISTRY_ID \
     --subscription $SUBSCRIPTION
 ```
@@ -281,7 +291,7 @@ az acr repository show-tags \
 | Provision | Step 1 | Verifies the feature flag is `Registered` |
 | Provision | Step 2 | Creates the UAMI if it does not exist |
 | Provision | Step 3 | Enables ABAC (`AbacRepositoryPermissions`) on the source registry if not already set |
-| Provision | Step 4 | Assigns `Container Registry Repository Reader` role on the source registry if missing |
+| Provision | Step 4 | Assigns `Container Registry Repository Reader` role (and optionally `Container Registry Repository Catalog Lister`) to the UAMI on the source registry |
 | Provision | Step 5 | Assigns the UAMI to the source registry if missing |
 | Provision | Step 6 | Assigns the UAMI to the target registry if missing |
 | Provision | Step 7 | Deploys the Bicep module to create the cache rule if it does not exist |

--- a/demos/kubecon-eu-2026/acr-to-acr-mi/test/test-cache-rule.sh
+++ b/demos/kubecon-eu-2026/acr-to-acr-mi/test/test-cache-rule.sh
@@ -23,8 +23,19 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC
 pass()  { echo -e "${GREEN}[PASS]${NC} $*"; }
 fail()  { echo -e "${RED}[FAIL]${NC} $*"; FAILURES=$((FAILURES + 1)); }
 info()  { echo -e "${YELLOW}[INFO]${NC} $*"; }
-# run  — print + execute a provisioning command (stdout goes to terminal)
-run()   { echo -e "${CYAN}[CMD]${NC} $*" > /dev/tty; "$@"; }
+# run  — print + execute a provisioning command; prints [ERROR] + stderr on failure
+run() {
+  echo -e "${CYAN}[CMD]${NC} $*" > /dev/tty
+  local _err_file
+  _err_file=$(mktemp)
+  if ! "$@" 2>"$_err_file"; then
+    local _rc=$?
+    [[ -s "$_err_file" ]] && echo -e "${RED}[ERROR]${NC} $(cat "$_err_file")" > /dev/tty
+    rm -f "$_err_file"
+    return $_rc
+  fi
+  rm -f "$_err_file"
+}
 # query — print + execute a query command whose stdout is captured via $(...)
 #          writes to /dev/tty so the [CMD] line is never suppressed by 2>/dev/null
 query() { echo -e "${CYAN}[CMD]${NC} $*" > /dev/tty; "$@"; }
@@ -174,6 +185,27 @@ else
     pass "'Container Registry Repository Reader' assigned on source registry"
   fi
 
+  # Optional: needed only if clients want to list available tags on the source registry
+  LISTER_COUNT=$(query az role assignment list \
+    --assignee "$UAMI_PRINCIPAL_ID" \
+    --role "Container Registry Repository Catalog Lister" \
+    --scope "$SOURCE_REGISTRY_SCOPE" \
+    --subscription "$SUBSCRIPTION" \
+    --query "length(@)" \
+    --output tsv 2>/dev/null || echo "0")
+  if [[ "$LISTER_COUNT" -ge 1 ]]; then
+    pass "'Container Registry Repository Catalog Lister' already assigned on source registry"
+  else
+    info "  Assigning 'Container Registry Repository Catalog Lister' to UAMI on source registry..."
+    run az role assignment create \
+      --assignee "$UAMI_PRINCIPAL_ID" \
+      --role "Container Registry Repository Catalog Lister" \
+      --scope "$SOURCE_REGISTRY_SCOPE" \
+      --subscription "$SUBSCRIPTION" \
+      --output none
+    pass "'Container Registry Repository Catalog Lister' assigned on source registry"
+  fi
+
 fi
 
 # ── Step 5: UAMI assigned to source registry (assign if missing) ─────────────
@@ -259,7 +291,7 @@ info "Test 1: Pull image through the target registry cache"
 IMAGE="${TARGET_REGISTRY}.azurecr.io/${TARGET_REPO}:${IMAGE_TAG}"
 
 info "  Pulling $IMAGE ..."
-if run docker pull "$IMAGE" > /dev/null 2>&1; then
+if run docker pull "$IMAGE"; then
   pass "Image pulled successfully: $IMAGE"
 else
   fail "Failed to pull image: $IMAGE"
@@ -288,7 +320,7 @@ run az acr cache show \
   --registry "$TARGET_REGISTRY" \
   --resource-group "$RESOURCE_GROUP" \
   --subscription "$SUBSCRIPTION" \
-  --output json 2>/dev/null || true
+  --output json || true
 
 # ── Show UAMI role assignments on source registry ─────────────────────────────
 echo ""
@@ -304,7 +336,7 @@ run az role assignment list \
   --scope "$SOURCE_REGISTRY_SCOPE" \
   --subscription "$SUBSCRIPTION" \
   --query "[].{Role:roleDefinitionName, PrincipalType:principalType, Scope:scope}" \
-  --output table 2>/dev/null || true
+  --output table || true
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Overview

Follow-up to #30. Adds improvements to the ACR-to-ACR cache rule demo made after the initial PR was merged.

## Changes

### 1. Remove target registry identity assignment step

The step that assigned the UAMI to the target registry has been removed from both the README and the setup script — it is not required for the cache rule to function.

- **README**: Step 8 (Assign the Identity to the Target Registry) removed; subsequent steps renumbered (old 9→8, 10→9, 11→10). Stale troubleshooting row referencing this step also removed from both troubleshooting tables.
- **Script**: Step 6 (UAMI assigned to target registry) removed; old Step 7 (cache rule deploy) renumbered to Step 6.
- **Script table in README**: Step 6 row removed, Step 7 row renumbered to Step 6; stale `AbacRepositoryPermissions` label corrected to `rbac-abac`.

### 2. Error reporting in the setup script

The `run()` helper now captures stderr to a temp file and prints it as `[ERROR] <message>` (in red) when a provisioning command fails, making it immediately clear which step failed and why.

### 3. Catalog Lister role reinstated with caveat

The `Container Registry Repository Catalog Lister` role assignment (Step 4 in script) was re-added with a clear note that it is **optional** — only needed if clients want to enumerate all available tags on the source registry. It is **not** required for image pulls through the cache.

- Script: block prefixed with `# Optional: needed only if clients want to list available tags on the source registry`
- README Step 6: primary Reader role block followed by a separate optional Catalog Lister block with the caveat

### 4. docker pull output no longer suppressed

Removed `> /dev/null 2>&1` from the `docker pull` call in Test 1. Pull progress and any error output are now fully visible in the terminal.

## Step alignment (README ↔ script)

| Script Step | README Step | Action |
|-------------|-------------|--------|
| Auth | Steps 1–2 | Login, subscription, ACR login |
| Step 1 | Step 3 | Verify feature flag is `Registered` |
| Step 2 | Step 4 | Create UAMI if missing |
| Step 3 | Step 5 | Enable ABAC (`rbac-abac`) on source registry |
| Step 4 | Step 6 | Assign Reader role (+ optional Catalog Lister) to UAMI |
| Step 5 | Step 7 | Assign UAMI to source registry |
| Step 6 | Step 8 | Deploy Bicep module to create cache rule |
| Test 1–2 | Steps 9–10 | Pull image through cache; verify tag visible |

## Files changed

| File | Change |
|------|--------|
| `demos/kubecon-eu-2026/acr-to-acr-mi/test/test-cache-rule.sh` | Updated `run()` helper; re-added Catalog Lister block; removed output suppression on docker pull; removed Step 6 (target identity); renumbered Step 7→6 |
| `demos/kubecon-eu-2026/acr-to-acr-mi/README.md` | Removed Step 8 (target identity); renumbered Steps 9–11 to 8–10; fixed troubleshooting tables; corrected script table labels |
