### PR TITLE
fix(acr-to-acr-mi): remove target registry identity assignment step, align script and README steps

### DIFF
--- a/demos/kubecon-eu-2026/acr-to-acr-mi/README.md
+++ b/demos/kubecon-eu-2026/acr-to-acr-mi/README.md
@@ -185,28 +185,7 @@ az acr identity assign \
 
 ---
 
-## Step 8 — Assign the Identity to the Target Registry
-
-The managed identity must also be associated with the target (downstream) registry so ACR can use it when executing cache pulls.
-
-```bash
-TARGET_REGISTRY_ID=$(az acr show \
-    --name $TARGET_REGISTRY \
-    --resource-group $RESOURCE_GROUP \
-    --subscription $SUBSCRIPTION \
-    --query "id" \
-    --output tsv)
-
-az acr identity assign \
-    --name $TARGET_REGISTRY \
-    --identities $UAMI_RESOURCE_ID \
-    --resource-group $RESOURCE_GROUP \
-    --subscription $SUBSCRIPTION
-```
-
----
-
-## Step 9 — Deploy the Bicep Module
+## Step 8 — Deploy the Bicep Module
 
 Deploy [cache-rule.bicep](cache-rule.bicep) to create the cache rule on the target registry.
 
@@ -235,7 +214,7 @@ az deployment group create \
 
 ---
 
-## Step 10 — Verify the Cache Rule
+## Step 9 — Verify the Cache Rule
 
 Confirm the cache rule was created successfully:
 
@@ -249,7 +228,7 @@ az acr cache show \
 
 ---
 
-## Step 11 — Test the Cache
+## Step 10 — Test the Cache
 
 Pull an image through the target registry. ACR will transparently fetch it from the source registry using the managed identity.
 
@@ -273,7 +252,6 @@ az acr repository show-tags \
 | Symptom | Likely Cause | Resolution |
 |---|---|---|
 | Deployment fails with `FeatureNotEnabled` | Feature flag not yet `Registered` | Re-check Step 3; wait for `Registered` state |
-| `AuthorizationFailed` on cache rule create | Identity not assigned to the target registry | Complete Step 8 before deploying |
 | Pull through cache returns `unauthorized` | Identity missing required roles on source registry | Verify role assignments from Step 6; confirm ABAC is enabled (Step 5) |
 | Feature registration stuck in `Registering` | Normal for preview features | Wait up to 15 minutes; re-run the `az feature show` check |
 
@@ -290,11 +268,10 @@ az acr repository show-tags \
 | Auth | — | `az login` (if not already authenticated), `az account set`, `az acr login` |
 | Provision | Step 1 | Verifies the feature flag is `Registered` |
 | Provision | Step 2 | Creates the UAMI if it does not exist |
-| Provision | Step 3 | Enables ABAC (`AbacRepositoryPermissions`) on the source registry if not already set |
+| Provision | Step 3 | Enables ABAC (`rbac-abac` mode) on the source registry if not already set |
 | Provision | Step 4 | Assigns `Container Registry Repository Reader` role (and optionally `Container Registry Repository Catalog Lister`) to the UAMI on the source registry |
 | Provision | Step 5 | Assigns the UAMI to the source registry if missing |
-| Provision | Step 6 | Assigns the UAMI to the target registry if missing |
-| Provision | Step 7 | Deploys the Bicep module to create the cache rule if it does not exist |
+| Provision | Step 6 | Deploys the Bicep module to create the cache rule if it does not exist |
 | Verify | Test 1 | Pulls an image through the target registry cache |
 | Verify | Test 2 | Confirms the pulled tag is visible in the target registry |
 
@@ -321,7 +298,6 @@ bash test/test-cache-rule.sh
 | Symptom | Likely Cause | Resolution |
 |---|---|---|
 | Deployment fails with `FeatureNotEnabled` | Feature flag not yet `Registered` | Re-check Step 3; wait for `Registered` state |
-| `AuthorizationFailed` on cache rule create | Identity not assigned to the target registry | Complete Step 8 before deploying |
 | Pull through cache returns `unauthorized` | Identity missing required roles on source registry | Verify role assignments from Step 6; confirm ABAC is enabled (Step 5) |
 | Feature registration stuck in `Registering` | Normal for preview features | Wait up to 15 minutes; re-run the `az feature show` check |
 

--- a/demos/kubecon-eu-2026/acr-to-acr-mi/test/test-cache-rule.sh
+++ b/demos/kubecon-eu-2026/acr-to-acr-mi/test/test-cache-rule.sh
@@ -230,30 +230,8 @@ else
   pass "UAMI assigned to source registry"
 fi
 
-# ── Step 6: UAMI assigned to target registry (assign if missing) ─────────────
-info "Step 6: UAMI assigned to target registry '$TARGET_REGISTRY'"
-TARGET_IDENTITIES=$(query az acr identity show \
-  --name "$TARGET_REGISTRY" \
-  --resource-group "$RESOURCE_GROUP" \
-  --subscription "$SUBSCRIPTION" \
-  --query "userAssignedIdentities" \
-  --output json 2>/dev/null || echo "{}")
-
-if [[ -n "$UAMI_ID" ]] && echo "$TARGET_IDENTITIES" | grep -qi "$(basename "$UAMI_ID")"; then
-  pass "UAMI already assigned to target registry"
-else
-  info "  Assigning UAMI to target registry..."
-  run az acr identity assign \
-    --name "$TARGET_REGISTRY" \
-    --identities "$UAMI_ID" \
-    --resource-group "$RESOURCE_GROUP" \
-    --subscription "$SUBSCRIPTION" \
-    --output none
-  pass "UAMI assigned to target registry"
-fi
-
-# ── Step 7: Cache rule (deploy via Bicep if missing) ─────────────────────────
-info "Step 7: Cache rule '$CACHE_RULE_NAME' on target registry '$TARGET_REGISTRY'"
+# ── Step 6: Cache rule (deploy via Bicep if missing) ─────────────────────────
+info "Step 6: Cache rule '$CACHE_RULE_NAME' on target registry '$TARGET_REGISTRY'"
 CACHE_RULE_JSON=$(query az acr cache show \
   --name "$CACHE_RULE_NAME" \
   --registry "$TARGET_REGISTRY" \


### PR DESCRIPTION
## Overview

Follow-up to #30 and #31. Removes the unnecessary target registry identity assignment step from the README and setup script, and aligns step numbering between the two.

## Changes

### README

- **Step 8 removed** — "Assign the Identity to the Target Registry" is not required for the cache rule to function
- **Steps renumbered**: old 9→8, 10→9, 11→10 (guide now has 10 steps)
- **Troubleshooting tables**: removed the stale /Step 8 row from both tables
- **Automated Setup Script table**: removed the Step 6 row (target registry identity), renumbered Step 7→6; corrected stale label  to 

### Setup script ()

- **Step 6 removed** — block that assigned the UAMI to the target registry
- **Step 7 renumbered to Step 6** — cache rule deploy via Bicep

## Step alignment (README ↔ script)

| Script Step | README Step | Action |
|-------------|-------------|--------|
| Auth | Steps 1–2 | Login, subscription, ACR login |
| Step 1 | Step 3 | Verify feature flag is  |
| Step 2 | Step 4 | Create UAMI if missing |
| Step 3 | Step 5 | Enable ABAC () on source registry |
| Step 4 | Step 6 | Assign Reader role (+ optional Catalog Lister) to UAMI |
| Step 5 | Step 7 | Assign UAMI to source registry |
| Step 6 | Step 8 | Deploy Bicep module to create cache rule |
| Test 1–2 | Steps 9–10 | Pull image through cache; verify tag visible |
