### PR TITLE
feat(artifact-signing): end-to-end demo for KubeCon EU 2026 - Azure Artifact Signing with Notation, Ratify, and Gatekeeper

### DIFF
--- a/demos/kubecon-eu-2026/acr-to-acr-mi/README.md
+++ b/demos/kubecon-eu-2026/acr-to-acr-mi/README.md
@@ -185,28 +185,7 @@ az acr identity assign \
 
 ---
 
-## Step 8 — Assign the Identity to the Target Registry
-
-The managed identity must also be associated with the target (downstream) registry so ACR can use it when executing cache pulls.
-
-```bash
-TARGET_REGISTRY_ID=$(az acr show \
-    --name $TARGET_REGISTRY \
-    --resource-group $RESOURCE_GROUP \
-    --subscription $SUBSCRIPTION \
-    --query "id" \
-    --output tsv)
-
-az acr identity assign \
-    --name $TARGET_REGISTRY \
-    --identities $UAMI_RESOURCE_ID \
-    --resource-group $RESOURCE_GROUP \
-    --subscription $SUBSCRIPTION
-```
-
----
-
-## Step 9 — Deploy the Bicep Module
+## Step 8 — Deploy the Bicep Module
 
 Deploy [cache-rule.bicep](cache-rule.bicep) to create the cache rule on the target registry.
 
@@ -235,7 +214,7 @@ az deployment group create \
 
 ---
 
-## Step 10 — Verify the Cache Rule
+## Step 9 — Verify the Cache Rule
 
 Confirm the cache rule was created successfully:
 
@@ -249,7 +228,7 @@ az acr cache show \
 
 ---
 
-## Step 11 — Test the Cache
+## Step 10 — Test the Cache
 
 Pull an image through the target registry. ACR will transparently fetch it from the source registry using the managed identity.
 
@@ -273,7 +252,6 @@ az acr repository show-tags \
 | Symptom | Likely Cause | Resolution |
 |---|---|---|
 | Deployment fails with `FeatureNotEnabled` | Feature flag not yet `Registered` | Re-check Step 3; wait for `Registered` state |
-| `AuthorizationFailed` on cache rule create | Identity not assigned to the target registry | Complete Step 8 before deploying |
 | Pull through cache returns `unauthorized` | Identity missing required roles on source registry | Verify role assignments from Step 6; confirm ABAC is enabled (Step 5) |
 | Feature registration stuck in `Registering` | Normal for preview features | Wait up to 15 minutes; re-run the `az feature show` check |
 
@@ -290,11 +268,10 @@ az acr repository show-tags \
 | Auth | — | `az login` (if not already authenticated), `az account set`, `az acr login` |
 | Provision | Step 1 | Verifies the feature flag is `Registered` |
 | Provision | Step 2 | Creates the UAMI if it does not exist |
-| Provision | Step 3 | Enables ABAC (`AbacRepositoryPermissions`) on the source registry if not already set |
+| Provision | Step 3 | Enables ABAC (`rbac-abac` mode) on the source registry if not already set |
 | Provision | Step 4 | Assigns `Container Registry Repository Reader` role (and optionally `Container Registry Repository Catalog Lister`) to the UAMI on the source registry |
 | Provision | Step 5 | Assigns the UAMI to the source registry if missing |
-| Provision | Step 6 | Assigns the UAMI to the target registry if missing |
-| Provision | Step 7 | Deploys the Bicep module to create the cache rule if it does not exist |
+| Provision | Step 6 | Deploys the Bicep module to create the cache rule if it does not exist |
 | Verify | Test 1 | Pulls an image through the target registry cache |
 | Verify | Test 2 | Confirms the pulled tag is visible in the target registry |
 
@@ -321,7 +298,6 @@ bash test/test-cache-rule.sh
 | Symptom | Likely Cause | Resolution |
 |---|---|---|
 | Deployment fails with `FeatureNotEnabled` | Feature flag not yet `Registered` | Re-check Step 3; wait for `Registered` state |
-| `AuthorizationFailed` on cache rule create | Identity not assigned to the target registry | Complete Step 8 before deploying |
 | Pull through cache returns `unauthorized` | Identity missing required roles on source registry | Verify role assignments from Step 6; confirm ABAC is enabled (Step 5) |
 | Feature registration stuck in `Registering` | Normal for preview features | Wait up to 15 minutes; re-run the `az feature show` check |
 

--- a/demos/kubecon-eu-2026/acr-to-acr-mi/test/test-cache-rule.sh
+++ b/demos/kubecon-eu-2026/acr-to-acr-mi/test/test-cache-rule.sh
@@ -230,30 +230,8 @@ else
   pass "UAMI assigned to source registry"
 fi
 
-# ── Step 6: UAMI assigned to target registry (assign if missing) ─────────────
-info "Step 6: UAMI assigned to target registry '$TARGET_REGISTRY'"
-TARGET_IDENTITIES=$(query az acr identity show \
-  --name "$TARGET_REGISTRY" \
-  --resource-group "$RESOURCE_GROUP" \
-  --subscription "$SUBSCRIPTION" \
-  --query "userAssignedIdentities" \
-  --output json 2>/dev/null || echo "{}")
-
-if [[ -n "$UAMI_ID" ]] && echo "$TARGET_IDENTITIES" | grep -qi "$(basename "$UAMI_ID")"; then
-  pass "UAMI already assigned to target registry"
-else
-  info "  Assigning UAMI to target registry..."
-  run az acr identity assign \
-    --name "$TARGET_REGISTRY" \
-    --identities "$UAMI_ID" \
-    --resource-group "$RESOURCE_GROUP" \
-    --subscription "$SUBSCRIPTION" \
-    --output none
-  pass "UAMI assigned to target registry"
-fi
-
-# ── Step 7: Cache rule (deploy via Bicep if missing) ─────────────────────────
-info "Step 7: Cache rule '$CACHE_RULE_NAME' on target registry '$TARGET_REGISTRY'"
+# ── Step 6: Cache rule (deploy via Bicep if missing) ─────────────────────────
+info "Step 6: Cache rule '$CACHE_RULE_NAME' on target registry '$TARGET_REGISTRY'"
 CACHE_RULE_JSON=$(query az acr cache show \
   --name "$CACHE_RULE_NAME" \
   --registry "$TARGET_REGISTRY" \

--- a/demos/kubecon-eu-2026/artifact-signing/README.md
+++ b/demos/kubecon-eu-2026/artifact-signing/README.md
@@ -138,7 +138,7 @@ az codesigning account create \
 ```
 
 > **Note:** The `Basic` SKU is sufficient for Private Trust certificates used
-> in this demo. Use `Premium` for Public Trust certificates.
+> in this demo.
 
 ### 1.3 Create an identity validation
 
@@ -146,18 +146,21 @@ Identity validation must be completed in the **Azure portal**; it cannot be
 done via the CLI.
 
 1. Go to the Azure portal and open your new Artifact Signing account.
-2. Confirm you are assigned the **Artifact Signing Identity Verifier** role.
+2. Confirm you are assigned the following roles on the Artifact Signing account:
+   - **Artifact Signing Identity Verifier** — required to create identity validations.
+   - **Artifact Signing Certificate Profile Signer** — required to sign artifacts using a certificate profile.
 3. Select **Identity validations → New identity → Private**.
 4. Fill in the organization details (name, email, address, etc.).
 5. Select **Create** and wait for the status to change to **Completed**.
-   Processing takes 1–7 business days for Public Trust; Private Trust is
-   usually instant.
 
-> **Demo shortcut:** For a demo with a private trust certificate, use
-> **Private** validation. This skips the external identity verification step
-> and completes immediately within your Entra tenant.
+> **Important:** Use **Private** identity validation for this demo. Private
+> validation is scoped to your Entra tenant, completes immediately, and does
+> not require the external business verification process needed for Public Trust.
 
 ### 1.4 Create a certificate profile
+
+Use the **Private Trust** certificate profile type, which pairs with the
+Private identity validation created above and is scoped to your Entra tenant.
 
 ```bash
 az codesigning certificate-profile create \
@@ -176,6 +179,10 @@ az codesigning account show \
   --resource-group $TS_RG \
   --query "id" -o tsv
 ```
+
+> **Note:** The `PrivateTrust` profile type is the only type compatible with
+> Private identity validation. Do not use `PublicTrust` or other profile types
+> for this demo.
 
 ### 1.5 Assign the signer role
 

--- a/demos/kubecon-eu-2026/artifact-signing/README.md
+++ b/demos/kubecon-eu-2026/artifact-signing/README.md
@@ -1,0 +1,546 @@
+# End-to-End Container Image Signing with Azure Artifact Signing
+
+## Overview
+
+This demo shows a complete end-to-end container image signing and verification
+workflow using **Azure Artifact Signing** (formerly Azure Trusted Signing) and
+the **Notation CLI** with the `azure-artifactsigning` plugin. Signed images are
+then verified at deployment time on **AKS** using **Ratify** and **Gatekeeper**
+to enforce a policy that rejects any unsigned or improperly signed workload.
+
+### What is Azure Artifact Signing?
+
+Azure Artifact Signing is a Microsoft fully managed, end-to-end signing solution
+that simplifies certificate signing for organizations and developers. Key
+characteristics:
+
+- **Zero-touch certificate lifecycle management** inside FIPS 140-2 Level 3
+  certified HSMs.
+- **Short-lived certificates** (3-day validity) — timestamps are therefore
+  critical for long-term signature validation.
+- **Content-confidential signing** — only the digest of the artifact leaves the
+  endpoint; the artifact itself never leaves your environment.
+- **Timestamping service** at `http://timestamp.acs.microsoft.com/`.
+- Integrates with Notation, SignTool, GitHub Actions, Azure DevOps, and more.
+
+Service documentation: <https://learn.microsoft.com/en-us/azure/artifact-signing/>  
+Notation plugin repo: <https://github.com/Azure/artifact-signing-notation-plugin>
+
+---
+
+## Architecture
+
+```
+Developer workstation
+  └─ notation sign  ──────────────────────────────────────────────────────────┐
+       │  azure-artifactsigning plugin                                        │
+       ├─ digest sent to Azure Artifact Signing ──► HSM signs ──► signature  │
+       └─ signature pushed to ACR                                             │
+                                                                              ▼
+AKS cluster                                                            ACR registry
+  ├─ OPA Gatekeeper  (policy enforcement)                      wabbitregistry.azurecr.io
+  └─ Ratify           (signature verification)       net-monitor:v1 + attached signature
+       └─ notation verify (azure-artifactsigning plugin)
+```
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Azure CLI | ≥ 2.60 | `brew install azure-cli` |
+| Notation CLI | ≥ 1.1 | <https://notaryproject.dev/docs/installation/notation/> |
+| `azure-artifactsigning` plugin | ≥ 1.1.0 | see Step 5 below |
+| Docker | any | `brew install docker` |
+| `kubectl` | any | `brew install kubectl` |
+| `helm` | ≥ 3 | `brew install helm` |
+
+You also need:
+- An Azure subscription with an ACR instance (Premium SKU for OCI artifact support).
+- An AKS cluster with OIDC issuer and workload identity enabled.
+
+---
+
+## Environment Variables
+
+Set these before running any step:
+
+```bash
+# Azure Artifact Signing
+export TS_ACCT_NAME=tsdemo
+export TS_ACCT_URL=https://eus.codesigning.azure.net/   # matches the region of your account
+export TS_CERT_PROFILE=tsdemoprofile
+export TS_TSA_URL=http://timestamp.acs.microsoft.com/
+export TS_SIGNING_ROOT_CERT="https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt"
+export TS_TSA_ROOT_CERT="http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt"
+
+# ACR and image
+export ACR_LOGIN_SERVER=wabbitregistry.azurecr.io
+export REPOSITORY=net-monitor
+export IMAGE=wabbitregistry.azurecr.io/net-monitor:v1
+
+# Notation trust stores
+export SIGNING_TRUST_STORE=myRootCerts
+export TSA_TRUST_STORE=myTsaRootCerts
+export TS_CERT_SUBJECT="CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=tsdemo, S=Washington, C=US"
+
+# AKS
+export AKS_CLUSTER=<your-aks-cluster-name>
+export AKS_RG=<your-aks-resource-group>
+export ACR_RG=<your-acr-resource-group>
+```
+
+---
+
+## Step 1 — Create the Artifact Signing Account
+
+### 1.1 Register the resource provider
+
+The Artifact Signing resource provider (`Microsoft.CodeSigning`) must be
+registered in your Azure subscription before any resources can be created.
+
+```bash
+az provider register --namespace Microsoft.CodeSigning
+
+# Wait until RegistrationState is "Registered"
+az provider show --namespace Microsoft.CodeSigning --query "registrationState" -o tsv
+```
+
+> **Tip:** Registration can take a few minutes. Re-run the `show` command
+> until the output is `Registered`.
+
+### 1.2 Create the account
+
+Artifact Signing accounts are available in the following regions (partial list):
+
+| Region | Endpoint |
+|--------|----------|
+| East US | `https://eus.codesigning.azure.net` |
+| West Europe | `https://weu.codesigning.azure.net` |
+| North Europe | `https://neu.codesigning.azure.net` |
+| West US 2 | `https://wus2.codesigning.azure.net` |
+
+Account naming constraints: 3–24 alphanumeric characters, globally unique,
+starts with a letter, ends with a letter or digit, no consecutive hyphens.
+
+```bash
+export TS_RG=artifact-signing-rg
+export TS_LOCATION=eastus
+
+az group create --name $TS_RG --location $TS_LOCATION
+
+az codesigning account create \
+  --name $TS_ACCT_NAME \
+  --resource-group $TS_RG \
+  --location $TS_LOCATION \
+  --sku Basic
+```
+
+> **Note:** The `Basic` SKU is sufficient for Private Trust certificates used
+> in this demo. Use `Premium` for Public Trust certificates.
+
+### 1.3 Create an identity validation
+
+Identity validation must be completed in the **Azure portal**; it cannot be
+done via the CLI.
+
+1. Go to the Azure portal and open your new Artifact Signing account.
+2. Confirm you are assigned the **Artifact Signing Identity Verifier** role.
+3. Select **Identity validations → New identity → Private**.
+4. Fill in the organization details (name, email, address, etc.).
+5. Select **Create** and wait for the status to change to **Completed**.
+   Processing takes 1–7 business days for Public Trust; Private Trust is
+   usually instant.
+
+> **Demo shortcut:** For a demo with a private trust certificate, use
+> **Private** validation. This skips the external identity verification step
+> and completes immediately within your Entra tenant.
+
+### 1.4 Create a certificate profile
+
+```bash
+az codesigning certificate-profile create \
+  --account-name $TS_ACCT_NAME \
+  --resource-group $TS_RG \
+  --profile-name $TS_CERT_PROFILE \
+  --profile-type PrivateTrust \
+  --identity-validation-id <identity-validation-resource-id>
+```
+
+Retrieve the identity validation resource ID from the portal or:
+
+```bash
+az codesigning account show \
+  --name $TS_ACCT_NAME \
+  --resource-group $TS_RG \
+  --query "id" -o tsv
+```
+
+### 1.5 Assign the signer role
+
+The principal that will sign (typically your user or a service principal) must
+be assigned the **Artifact Signing Certificate Profile Signer** role on the
+certificate profile resource.
+
+```bash
+export SIGNER_PRINCIPAL_ID=$(az ad signed-in-user show --query id -o tsv)
+export CERT_PROFILE_ID=$(az codesigning certificate-profile show \
+  --account-name $TS_ACCT_NAME \
+  --resource-group $TS_RG \
+  --profile-name $TS_CERT_PROFILE \
+  --query id -o tsv)
+
+az role assignment create \
+  --role "Artifact Signing Certificate Profile Signer" \
+  --assignee $SIGNER_PRINCIPAL_ID \
+  --scope $CERT_PROFILE_ID
+```
+
+---
+
+## Step 2 — Install Notation and the Plugin
+
+### 2.1 Install the Notation CLI
+
+```bash
+# macOS (Homebrew)
+brew install notation
+
+# verify
+notation version
+```
+
+### 2.2 Install the `azure-artifactsigning` plugin
+
+```bash
+# Linux amd64
+notation plugin install \
+  --url https://github.com/Azure/artifact-signing-notation-plugin/releases/download/v1.1.0/notation-azure-artifactsigning_1.1.0_linux_amd64.tar.gz \
+  --sha256sum 459075a5cdadcdba334b728838d617fa330f19b45848ba993a4d2a061f49d4ac
+
+# macOS arm64
+notation plugin install \
+  --url https://github.com/Azure/artifact-signing-notation-plugin/releases/download/v1.1.0/notation-azure-artifactsigning_1.1.0_darwin_arm64.tar.gz \
+  --sha256sum f9ff085c86474b2371cf3acd70e24f067df2f5c2c3240e101957d99b55d480f0
+
+# confirm
+notation plugin ls
+```
+
+The plugin name shown by `notation plugin ls` must be `azure-artifactsigning`.
+
+---
+
+## Step 3 — Sign the Container Image
+
+Authenticate to ACR and Azure, then sign:
+
+```bash
+az login
+az acr login --name $ACR_LOGIN_SERVER
+
+# Download the TSA root certificate (needed for timestamping)
+curl -o msft-tsa-root-certificate-authority-2020.crt "$TS_TSA_ROOT_CERT"
+
+# Sign
+notation sign \
+  --signature-format cose \
+  --timestamp-url "$TS_TSA_URL" \
+  --timestamp-root-cert msft-tsa-root-certificate-authority-2020.crt \
+  --id "$TS_CERT_PROFILE" \
+  --plugin azure-artifactsigning \
+  --plugin-config accountName="$TS_ACCT_NAME" \
+  --plugin-config baseUrl="$TS_ACCT_URL" \
+  --plugin-config certProfile="$TS_CERT_PROFILE" \
+  "$IMAGE"
+```
+
+> **How it works:** The plugin sends only the image digest to the Artifact
+> Signing HSM. The HSM signs the digest and returns a signature. The signature
+> is timestamped by the Azure TSA so it remains valid after the certificate
+> expires (3-day validity window).
+
+### 3.1 Inspect the signature
+
+```bash
+# List attached signatures
+notation ls "$IMAGE"
+
+# Inspect the full signature envelope
+notation inspect "$IMAGE"
+```
+
+---
+
+## Step 4 — Verify the Image Locally
+
+### 4.1 Set up the trust store
+
+Download the signing root CA and add it together with the TSA root:
+
+```bash
+curl -o msft-root-certificate-authority-2020.crt "$TS_SIGNING_ROOT_CERT"
+
+# Add signing root CA
+notation cert add \
+  --type ca \
+  --store "$SIGNING_TRUST_STORE" \
+  msft-root-certificate-authority-2020.crt
+
+# Add TSA root CA
+notation cert add \
+  --type tsa \
+  --store "$TSA_TRUST_STORE" \
+  msft-tsa-root-certificate-authority-2020.crt
+
+# Confirm both are present
+notation cert ls
+```
+
+### 4.2 Configure the trust policy
+
+Import `trusted-signing/trustpolicy.json`:
+
+```bash
+notation policy import trusted-signing/trustpolicy.json
+notation policy show
+```
+
+The trust policy (`trustpolicy.json`) ties the registry scope to the trust
+stores and restricts signatures to the expected certificate subject:
+
+```json
+{
+    "version": "1.0",
+    "trustPolicies": [
+        {
+            "name": "myPolicy",
+            "registryScopes": [ "wabbitregistry.azurecr.io/net-monitor" ],
+            "signatureVerification": { "level": "strict" },
+            "trustStores": [ "ca:myRootCerts", "tsa:myTsaRootCerts" ],
+            "trustedIdentities": [
+                "x509.subject: CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=tsdemo, S=Washington, C=US"
+            ]
+        }
+    ]
+}
+```
+
+### 4.3 Verify
+
+```bash
+notation verify "$IMAGE"
+```
+
+A successful verification prints:
+```
+Successfully verified signature for wabbitregistry.azurecr.io/net-monitor@sha256:<digest>
+```
+
+---
+
+## Step 5 — Enforce Signatures on AKS with Ratify and Gatekeeper
+
+This section shows how to enforce a policy on an AKS cluster so that only
+images with a valid Artifact Signing signature can be deployed.
+
+### 5.1 Connect to the AKS cluster
+
+```bash
+az aks get-credentials \
+  --name "$AKS_CLUSTER" \
+  --resource-group "$AKS_RG"
+```
+
+### 5.2 Install OPA Gatekeeper
+
+```bash
+helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
+helm repo update
+
+helm install gatekeeper gatekeeper/gatekeeper \
+  --namespace gatekeeper-system \
+  --create-namespace \
+  --set enableExternalData=true \
+  --set validatingWebhookTimeoutSeconds=5 \
+  --set mutatingWebhookTimeoutSeconds=2
+```
+
+### 5.3 Install Ratify
+
+```bash
+helm repo add ratify https://ratify-project.github.io/ratify
+helm repo update
+
+# Grant AKS kubelet identity pull access to ACR
+export KUBELET_CLIENT_ID=$(az aks show \
+  --name "$AKS_CLUSTER" \
+  --resource-group "$AKS_RG" \
+  --query "identityProfile.kubeletidentity.clientId" -o tsv)
+
+az role assignment create \
+  --role AcrPull \
+  --assignee "$KUBELET_CLIENT_ID" \
+  --scope "$(az acr show --name $ACR_LOGIN_SERVER --resource-group $ACR_RG --query id -o tsv)"
+
+helm install ratify ratify/ratify \
+  --namespace gatekeeper-system \
+  --set featureFlags.RATIFY_CERT_ROTATION=true \
+  --set akvCertConfig.enabled=false
+```
+
+### 5.4 Configure Ratify with the Artifact Signing trust store
+
+Create a `VerifyConfig` that points Ratify at the Artifact Signing root CA:
+
+```bash
+# Base64-encode the root certificate
+ROOT_CERT_B64=$(base64 -w0 msft-root-certificate-authority-2020.crt)
+TSA_CERT_B64=$(base64 -w0 msft-tsa-root-certificate-authority-2020.crt)
+
+kubectl apply -f - <<EOF
+apiVersion: config.ratify.deislabs.io/v1beta1
+kind: CertificateStore
+metadata:
+  name: artifact-signing-root
+  namespace: gatekeeper-system
+spec:
+  provider: inline
+  parameters:
+    value: |
+      $(cat msft-root-certificate-authority-2020.crt)
+---
+apiVersion: config.ratify.deislabs.io/v1beta1
+kind: CertificateStore
+metadata:
+  name: artifact-signing-tsa-root
+  namespace: gatekeeper-system
+spec:
+  provider: inline
+  parameters:
+    value: |
+      $(cat msft-tsa-root-certificate-authority-2020.crt)
+---
+apiVersion: config.ratify.deislabs.io/v1beta1
+kind: Verifier
+metadata:
+  name: verifier-notation
+  namespace: gatekeeper-system
+spec:
+  name: notation
+  artifactTypes: application/vnd.cncf.notary.signature
+  parameters:
+    verificationCertStores:
+      ca:
+        caCerts:
+          - artifact-signing-root
+      tsa:
+        tsaCerts:
+          - artifact-signing-tsa-root
+    trustPolicyDoc:
+      version: "1.0"
+      trustPolicies:
+        - name: default
+          registryScopes:
+            - "*"
+          signatureVerification:
+            level: strict
+          trustStores:
+            - "ca:caCerts"
+            - "tsa:tsaCerts"
+          trustedIdentities:
+            - "x509.subject: $TS_CERT_SUBJECT"
+EOF
+```
+
+### 5.5 Apply the Gatekeeper constraint
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: ratifyverification
+spec:
+  crd:
+    spec:
+      names:
+        kind: RatifyVerification
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package ratifyverification
+        import future.keywords.if
+        violation[{"msg": msg}] if {
+          subject := input.review.object.spec.containers[_].image
+          response := external_data({"provider": "ratify", "keys": [subject]})
+          result := response.responses[_]
+          result[0] == subject
+          result[1].isSuccess == false
+          msg := sprintf("Signature verification failed for image %v: %v", [subject, result[1].verifierReports])
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RatifyVerification
+metadata:
+  name: require-notation-signature
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces:
+      - default
+EOF
+```
+
+### 5.6 Test the policy
+
+**Deploy a signed image (should succeed):**
+
+```bash
+kubectl run signed-demo \
+  --image="$IMAGE" \
+  --restart=Never
+
+kubectl get pod signed-demo
+```
+
+**Deploy an unsigned image (should be rejected):**
+
+```bash
+kubectl run unsigned-demo \
+  --image=nginx:latest \
+  --restart=Never
+```
+
+Expected output:
+```
+Error from server (Forbidden): admission webhook "validation.gatekeeper.sh" denied the request:
+  Signature verification failed for image nginx:latest: ...
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Remedy |
+|---------|-------------|--------|
+| `notation sign` fails with `403 Forbidden` | Endpoint region mismatch or missing signer role | Verify `TS_ACCT_URL` matches the account region; check role assignment |
+| `notation verify` fails with `certificate expired` | TSA timestamp not applied | Re-sign with `--timestamp-url` and `--timestamp-root-cert` |
+| Ratify rejects all images including signed ones | Wrong certificate subject in `trustedIdentities` | Run `notation inspect $IMAGE` and copy the exact subject string |
+| Gatekeeper webhook times out | Ratify pod not ready | Check `kubectl get pods -n gatekeeper-system` and Ratify logs |
+| `az provider register` stuck | Normal; can take a few minutes | Retry `az provider show --namespace Microsoft.CodeSigning --query registrationState` |
+
+---
+
+## References
+
+- [Azure Artifact Signing overview](https://learn.microsoft.com/en-us/azure/artifact-signing/overview)
+- [Quickstart: Set up Artifact Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/quickstart)
+- [Artifact Signing Notation Plugin (GitHub)](https://github.com/Azure/artifact-signing-notation-plugin)
+- [Notary Project / Notation](https://notaryproject.dev/)
+- [Ratify](https://ratify.dev/)
+- [OPA Gatekeeper](https://open-policy-agent.github.io/gatekeeper/)
+- [Demo script](trusted-signing/demo-trusted-signing.sh)

--- a/demos/kubecon-eu-2026/artifact-signing/demo-magic.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/demo-magic.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+
+###############################################################################
+#
+# demo-magic.sh
+#
+# Copyright (c) 2015-2022 Paxton Hare
+#
+# This script lets you script demos in bash. It runs through your demo script
+# when you press ENTER. It simulates typing and runs commands.
+#
+###############################################################################
+
+# the speed to simulate typing the text
+TYPE_SPEED=20
+
+# no wait after "p" or "pe"
+NO_WAIT=false
+
+# if > 0, will pause for this amount of seconds before automatically proceeding with any p or pe
+PROMPT_TIMEOUT=0
+
+# don't show command number unless user specifies it
+SHOW_CMD_NUMS=false
+
+
+# handy color vars for pretty prompts
+BLACK="\033[0;30m"
+BLUE="\033[0;34m"
+GREEN="\033[0;32m"
+GREY="\033[0;90m"
+CYAN="\033[0;36m"
+RED="\033[0;31m"
+PURPLE="\033[0;35m"
+BROWN="\033[0;33m"
+WHITE="\033[0;37m"
+BOLD="\033[1m"
+COLOR_RESET="\033[0m"
+
+C_NUM=0
+
+# prompt and command color which can be overriden
+DEMO_PROMPT="$ "
+DEMO_CMD_COLOR=$BOLD
+DEMO_COMMENT_COLOR=$GREY
+
+##
+# prints the script usage
+##
+function usage() {
+  echo -e ""
+  echo -e "Usage: $0 [options]"
+  echo -e ""
+  echo -e "  Where options is one or more of:"
+  echo -e "  -h  Prints Help text"
+  echo -e "  -d  Debug mode. Disables simulated typing"
+  echo -e "  -n  No wait"
+  echo -e "  -w  Waits max the given amount of seconds before "
+  echo -e "      proceeding with demo (e.g. '-w5')"
+  echo -e ""
+}
+
+##
+# wait for user to press ENTER
+# if $PROMPT_TIMEOUT > 0 this will be used as the max time for proceeding automatically
+##
+function wait() {
+  if [[ "$PROMPT_TIMEOUT" == "0" ]]; then
+    read -rs
+  else
+    read -rst "$PROMPT_TIMEOUT"
+  fi
+}
+
+##
+# print command only. Useful for when you want to pretend to run a command
+#
+# takes 1 param - the string command to print
+#
+# usage: p "ls -l"
+#
+##
+function p() {
+  if [[ ${1:0:1} == "#" ]]; then
+    cmd=$DEMO_COMMENT_COLOR$1$COLOR_RESET
+  else
+    cmd=$DEMO_CMD_COLOR$1$COLOR_RESET
+  fi
+
+  # render the prompt
+  x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
+
+  # show command number is selected
+  if $SHOW_CMD_NUMS; then
+   printf "[$((++C_NUM))] $x"
+  else
+   printf "$x"
+  fi
+
+  # wait for the user to press a key before typing the command
+  if [ $NO_WAIT = false ]; then
+    wait
+  fi
+
+  if [[ -z $TYPE_SPEED ]]; then
+    echo -en "$cmd"
+  else
+    echo -en "$cmd" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
+  fi
+
+  # wait for the user to press a key before moving on
+  if [ $NO_WAIT = false ]; then
+    wait
+  fi
+  echo ""
+}
+
+##
+# Prints and executes a command
+#
+# takes 1 parameter - the string command to run
+#
+# usage: pe "ls -l"
+#
+##
+function pe() {
+  # print the command
+  p "$@"
+  run_cmd "$@"
+}
+
+##
+# print and executes a command immediately
+#
+# takes 1 parameter - the string command to run
+#
+# usage: pei "ls -l"
+#
+##
+function pei {
+  NO_WAIT=true pe "$@"
+}
+
+##
+# Enters script into interactive mode
+#
+# and allows newly typed commands to be executed within the script
+#
+# usage : cmd
+#
+##
+function cmd() {
+  # render the prompt
+  x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
+  printf "$x\033[0m"
+  read command
+  run_cmd "${command}"
+}
+
+##
+# Enters script into repl mode
+#
+# and allows newly typed commands to be executed within the script
+#
+# type exit to leave the repl
+#
+# usage : repl
+#
+##
+function repl() {
+  # render the prompt
+  looping=true
+  while $looping; do
+    x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
+    printf "$x\033[0m"
+    read command
+    if [[ "$command" == "exit" ]]; then
+      looping=false
+    else
+      run_cmd "$command"
+    fi
+  done
+}
+
+function run_cmd() {
+  function handle_cancel() {
+    printf ""
+  }
+
+  trap handle_cancel SIGINT
+  stty -echoctl
+  eval $@
+  stty echoctl
+  trap - SIGINT
+}
+
+
+function check_pv() {
+  command -v pv >/dev/null 2>&1 || {
+
+    echo ""
+    echo -e "${RED}##############################################################"
+    echo "# HOLD IT!! I require pv for simulated typing but it's " >&2
+    echo "# not installed. Aborting." >&2;
+    echo -e "${RED}##############################################################"
+    echo ""
+    echo -e "${COLOR_RESET}Disable simulated typing: "
+    echo ""
+    echo -e "   unset TYPE_SPEED"
+    echo ""
+    echo "Installing pv:"
+    echo ""
+    echo  "   Mac: $ brew install pv"
+    echo ""
+    echo  "   Other: https://www.ivarch.com/programs/pv.shtml"
+    echo  ""
+    exit 1;
+  }
+}
+
+#
+# handle some default params
+# -h for help
+# -d for disabling simulated typing
+#
+while getopts ":dhncw:" opt; do
+  case $opt in
+    h)
+      usage
+      exit 1
+      ;;
+    d)
+      unset TYPE_SPEED
+      ;;
+    n)
+      NO_WAIT=true
+      ;;
+    c)
+      SHOW_CMD_NUMS=true
+      ;;
+    w)
+      PROMPT_TIMEOUT=$OPTARG
+      ;;
+  esac
+done
+
+##
+# Do not check for pv. This trusts the user to not set TYPE_SPEED later in the
+# demo in which case an error will occur if pv is not installed.
+##
+if [[ -n "$TYPE_SPEED" ]]; then
+  check_pv
+fi

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+#################################
+# include the -=magic=-
+# you can pass command line args
+#
+# example:
+# to disable simulated typing
+# . ../demo-magic.sh -d
+#
+# pass -h to see all options
+#################################
+. ../demo-magic.sh -d
+
+
+########################
+# Configure the options
+########################
+
+#
+# speed at which to simulate typing. bigger num = faster
+#
+TYPE_SPEED=20
+
+#
+# custom prompt
+#
+# see http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/bash-prompt-escape-sequences.html for escape sequences
+#
+#DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
+DEMO_PROMPT="${GREEN}$ ${COLOR_RESET}"
+
+# text color
+# DEMO_CMD_COLOR=$BLACK
+
+# clean up any previous runs
+notation plugin uninstall azure-artifactsigning --yes
+notation cert delete --type ca --store $SIGNING_TRUST_STORE --all --yes
+notation cert delete --type tsa --store $TSA_TRUST_STORE --all --yes
+rm -f ~/.config/notation/trustpolicy.json
+rm -f msft-root-certificate-authority-2020.crt msft-tsa-root-certificate-authority-2020.crt
+rm -fr ~/.config/notation
+
+# hide the evidence
+clear
+
+# enters interactive mode and allows newly typed command to be executed
+cmd
+
+# print and execute immediately: ls -l
+
+# Set up env variables
+
+pe "# Set up variables for Trusted Signing"
+pe "TS_ACCT_NAME=sig-tsm-demo"
+pe "TS_ACCT_URL=https://wus2.codesigning.azure.net/"
+pe "TS_CERT_PROFILE=cert-tsm-demo"
+pe "TS_TSA_URL=http://timestamp.acs.microsoft.com/"
+pe "TS_SIGNING_ROOT_CERT=\"https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt\""
+
+echo
+pe "# Set up variables for ACR and image"
+pe "ACR_LOGIN_SERVER=acrtsmpremiumsku.azurecr.io"
+pe "REPOSITORY=python"
+pe "IMAGE=acrtsmpremiumsku.azurecr.io/python:3.13"
+
+echo
+pe "# Set up variables for signature verification"
+pe "TS_TSA_ROOT_CERT=\"http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt\""
+pe "SIGNING_TRUST_STORE=kubeconDemoSigningRootCerts"
+pe "TSA_TRUST_STORE=kubeconDemoTsaRootCerts"
+pe "TS_CERT_SUBJECT=\"CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=Cloud Native Security and Registries, L=Redmond, S=Washington, C=US\""
+
+echo
+pe "# Log in to ACR"
+pe "az login"
+pe "az acr login --name $ACR_LOGIN_SERVER"
+
+echo
+pe "# Confirm notation is installed"
+pe "notation version"
+
+echo
+pe "# Check the plugin"
+pe "notation plugin ls"
+
+echo
+pe "# Install the plugin"
+pe "notation plugin install --url https://github.com/Azure/artifact-signing-notation-plugin/releases/download/v1.1.0/notation-azure-artifactsigning_1.1.0_darwin_arm64.tar.gz --sha256sum f9ff085c86474b2371cf3acd70e24f067df2f5c2c3240e101957d99b55d480f0"
+
+echo
+pe "# List the plugin"
+pe "notation plugin ls"
+
+echo
+pe "# Download the TSA root certificate"
+pe "curl -o msft-tsa-root-certificate-authority-2020.crt $TS_TSA_ROOT_CERT"
+
+echo
+pe "# Sign the container image"
+pe "notation sign --signature-format cose --timestamp-url $TS_TSA_URL --timestamp-root-cert "msft-tsa-root-certificate-authority-2020.crt" --id $TS_CERT_PROFILE --plugin azure-artifactsigning --plugin-config accountName=$TS_ACCT_NAME --plugin-config baseUrl=$TS_ACCT_URL --plugin-config certProfile=$TS_CERT_PROFILE $IMAGE"
+
+echo
+pe "# List the signature"
+pe "notation ls $IMAGE"
+
+echo
+pe "# Inpsect the signature"
+pe "notation inspect $IMAGE"
+
+echo
+pe "# Set up trust store"
+pe "curl -o msft-root-certificate-authority-2020.crt $TS_SIGNING_ROOT_CERT"
+pe "notation cert add --type ca --store $SIGNING_TRUST_STORE msft-root-certificate-authority-2020.crt"
+pe "notation cert add -t tsa -s $TSA_TRUST_STORE msft-tsa-root-certificate-authority-2020.crt"
+
+echo
+pe "# List the trust store"
+pe "notation cert ls"
+
+echo
+pe "# Set up trust policy"
+pe "notation policy import trustpolicy.json"
+
+echo
+pe "# Show trust policy"
+pe "notation policy show"
+
+echo
+pe "# Verify the image"
+pe "notation verify $IMAGE"
+
+# run command behind
+
+# enters interactive mode and allows newly typed command to be executed
+
+# show a prompt so as not to reveal our true nature after
+# the demo has concluded
+p ""

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "trustPolicies": [
+        {
+            "name": "demoPolicy",
+            "registryScopes": [ "acrtsmpremiumsku.azurecr.io/python" ],
+            "signatureVerification": {
+                "level" : "strict"
+            },
+            "trustStores": [ "ca:kubeconDemoSigningRootCerts", "tsa:kubeconDemoTsaRootCerts" ],
+            "trustedIdentities": [
+                "x509.subject: CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=Cloud Native Security and Registries, L=Redmond, S=Washington, C=US"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Overview

Adds a complete end-to-end demo for KubeCon EU 2026 showing how to sign container images with **Azure Artifact Signing** (using the Notation CLI and the `azure-artifactsigning` plugin) and enforce signature verification at deployment time on **AKS** using **Ratify** and **Gatekeeper**.

## New files

| File | Description |
|------|-------------|
| `demos/kubecon-eu-2026/artifact-signing/README.md` | Step-by-step guide covering account setup through AKS policy enforcement |
| `demos/kubecon-eu-2026/artifact-signing/demo-magic.sh` | Demo magic helper script |
| `demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh` | Demo script: install plugin, sign, inspect, verify, and clean up |
| `demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json` | Notation trust policy scoped to the demo registry and certificate subject |

## Demo flow (README)

1. **Register** the `Microsoft.CodeSigning` resource provider
2. **Create** the Artifact Signing account (Basic SKU)
3. **Create** a Private identity validation (portal only — completes immediately within Entra tenant)
4. **Create** a Private Trust certificate profile
5. **Assign** required RBAC roles: `Artifact Signing Identity Verifier` + `Artifact Signing Certificate Profile Signer`
6. **Install** the Notation CLI and `azure-artifactsigning` plugin (v1.1.0)
7. **Sign** the container image with COSE signature format and RFC 3161 timestamp
8. **Verify** locally using a CA trust store, TSA trust store, and a strict trust policy
9. **Install** OPA Gatekeeper and Ratify on AKS via Helm
10. **Configure** Ratify with Artifact Signing root CA and TSA root CA certificates
11. **Apply** a Gatekeeper `ConstraintTemplate` + `RatifyVerification` constraint
12. **Test** that signed images are admitted and unsigned images are rejected

## Demo script highlights

- Uses **Private Trust** certificate profile (scoped to Entra tenant, no external CA validation required)
- Plugin v1.1.0 for macOS arm64 (sha256 verified install via `notation plugin install`)
- Timestamping via `http://timestamp.acs.microsoft.com/` ensures signatures remain valid beyond the 3-day certificate window
- **Cleanup steps** at the end: uninstall plugin, delete CA and TSA trust stores, remove trust policy file, and delete downloaded certificate files

## Key technical details

- **Identity**: Private (Entra-tenant-scoped, instant approval)
- **Certificate profile type**: Private Trust
- **Signature format**: COSE
- **Trust store names**: `kubeconDemoSigningRootCerts` (CA), `kubeconDemoTsaRootCerts` (TSA)
- **Endpoint**: `https://wus2.codesigning.azure.net/` (West US 2)
