### PR TITLE
feat(artifact-signing): add Kubernetes manifests for signed and unsigned NGINX demo

### DIFF
--- a/demos/kubecon-eu-2026/artifact-signing/README.md
+++ b/demos/kubecon-eu-2026/artifact-signing/README.md
@@ -83,7 +83,7 @@ export IMAGE=wabbitregistry.azurecr.io/net-monitor:v1
 # Notation trust stores
 export SIGNING_TRUST_STORE=myRootCerts
 export TSA_TRUST_STORE=myTsaRootCerts
-export TS_CERT_SUBJECT="CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052"
+export TS_CERT_SUBJECT="CN=toddysmlive.onmicrosoft.com,OU=Cloud Native Security and Registries,O=toddysmlive.onmicrosoft.com,L=Redmond,ST=Washington,C=US"
 
 # AKS
 export AKS_CLUSTER=<your-aks-cluster-name>
@@ -327,7 +327,7 @@ stores and restricts signatures to the expected certificate subject:
             "signatureVerification": { "level": "strict" },
             "trustStores": [ "ca:myRootCerts", "tsa:myTsaRootCerts" ],
             "trustedIdentities": [
-                "x509.subject: CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052"
+                "x509.subject: CN=toddysmlive.onmicrosoft.com,OU=Cloud Native Security and Registries,O=toddysmlive.onmicrosoft.com,L=Redmond,ST=Washington,C=US"
             ]
         }
     ]

--- a/demos/kubecon-eu-2026/artifact-signing/README.md
+++ b/demos/kubecon-eu-2026/artifact-signing/README.md
@@ -327,7 +327,7 @@ stores and restricts signatures to the expected certificate subject:
             "signatureVerification": { "level": "strict" },
             "trustStores": [ "ca:myRootCerts", "tsa:myTsaRootCerts" ],
             "trustedIdentities": [
-                "x509.subject: CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=tsdemo, S=Washington, C=US"
+                "x509.subject: CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052"
             ]
         }
     ]

--- a/demos/kubecon-eu-2026/artifact-signing/README.md
+++ b/demos/kubecon-eu-2026/artifact-signing/README.md
@@ -83,7 +83,7 @@ export IMAGE=wabbitregistry.azurecr.io/net-monitor:v1
 # Notation trust stores
 export SIGNING_TRUST_STORE=myRootCerts
 export TSA_TRUST_STORE=myTsaRootCerts
-export TS_CERT_SUBJECT="CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=tsdemo, S=Washington, C=US"
+export TS_CERT_SUBJECT="CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052"
 
 # AKS
 export AKS_CLUSTER=<your-aks-cluster-name>

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -59,7 +59,7 @@ export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-kueu26-demo}"
 # Identity validation ID — required for certificate profile creation.
 # Find it in the Portal: Trusted Signing → <account> → Identity validation
 # The GUID is shown in the identity validation details.
-export TS_IDENTITY_VALIDATION_ID="${TS_IDENTITY_VALIDATION_ID:-}"
+export TS_IDENTITY_VALIDATION_ID="${TS_IDENTITY_VALIDATION_ID:-a768ae25-6256-4366-b38d-67daf7b1dee4}"
 
 # Certificate subject DN — used for display / Ratify policy only (not passed
 # to the CLI; the subject is derived from the identity validation at signing time).

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -20,7 +20,7 @@
 # Individual service variables (ACR_RG, AKS_RG, TS_RG, …) inherit these values
 # but can still be overridden independently if needed.
 ###############################################################################
-export DEMO_RG="${DEMO_RG:-rg-tsm-signing}"
+export DEMO_RG="${DEMO_RG:-rg-tsm-kubeconeu2026-demo}"
 export DEMO_LOCATION="${DEMO_LOCATION:-westus2}"
 
 ###############################################################################

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -72,6 +72,15 @@ export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-CN=toddysmlive.onmicrosoft.com,OU=Clo
 export TS_SIGNING_ROOT_CERT="${TS_SIGNING_ROOT_CERT:-https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt}"
 export TS_TSA_ROOT_CERT="${TS_TSA_ROOT_CERT:-http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt}"
 
+# Trusted Signing service endpoint URL for the account region.
+# The subdomain abbreviation differs from the Azure region name; update this
+# if the account is created in a different region.
+# Region map: eastus→eus  westus2→wus2  westeurope→weu  northeurope→neu
+export TS_ACCT_URL="${TS_ACCT_URL:-https://wus2.codesigning.azure.net/}"
+
+# RFC 3161 timestamp authority URL (used by notation sign --timestamp-url)
+export TS_TSA_URL="${TS_TSA_URL:-http://timestamp.acs.microsoft.com/}"
+
 ###############################################################################
 # Log out and log back in to ensure a clean session on the correct subscription
 ###############################################################################

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -63,7 +63,7 @@ export TS_IDENTITY_VALIDATION_ID="${TS_IDENTITY_VALIDATION_ID:-a768ae25-6256-436
 
 # Certificate subject DN — used for display / Ratify policy only (not passed
 # to the CLI; the subject is derived from the identity validation at signing time).
-export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052}"
+export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-CN=toddysmlive.onmicrosoft.com,OU=Cloud Native Security and Registries,O=toddysmlive.onmicrosoft.com,L=Redmond,ST=Washington,C=US}"
 
 # Microsoft PKI certificate URLs (used by Ratify CertificateStore)
 export TS_SIGNING_ROOT_CERT="${TS_SIGNING_ROOT_CERT:-https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt}"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -63,7 +63,7 @@ export TS_IDENTITY_VALIDATION_ID="${TS_IDENTITY_VALIDATION_ID:-a768ae25-6256-436
 
 # Certificate subject DN — used for display / Ratify policy only (not passed
 # to the CLI; the subject is derived from the identity validation at signing time).
-export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-}"
+export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052}"
 
 # Microsoft PKI certificate URLs (used by Ratify CertificateStore)
 export TS_SIGNING_ROOT_CERT="${TS_SIGNING_ROOT_CERT:-https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt}"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -14,12 +14,22 @@
 #   source "${SCRIPT_DIR}/defaults.sh"
 
 ###############################################################################
+# Shared resource group and location
+# All services (ACR, AKS, Trusted Signing) are deployed into the same resource
+# group and region. Change DEMO_RG / DEMO_LOCATION here to move everything.
+# Individual service variables (ACR_RG, AKS_RG, TS_RG, …) inherit these values
+# but can still be overridden independently if needed.
+###############################################################################
+export DEMO_RG="${DEMO_RG:-rg-tsm-signing}"
+export DEMO_LOCATION="${DEMO_LOCATION:-westus2}"
+
+###############################################################################
 # Azure Container Registry
 ###############################################################################
 export ACR_NAME="${ACR_NAME:-acrtsmpremiumsku}"
-export ACR_RG="${ACR_RG:-rg-tsm-signing}"
+export ACR_RG="${ACR_RG:-${DEMO_RG}}"
 export ACR_SKU="${ACR_SKU:-Premium}"
-export ACR_LOCATION="${ACR_LOCATION:-westus2}"
+export ACR_LOCATION="${ACR_LOCATION:-${DEMO_LOCATION}}"
 # Derived from ACR_NAME — override explicitly if using a custom login server
 export ACR_LOGIN_SERVER="${ACR_LOGIN_SERVER:-${ACR_NAME}.azurecr.io}"
 
@@ -27,15 +37,15 @@ export ACR_LOGIN_SERVER="${ACR_LOGIN_SERVER:-${ACR_NAME}.azurecr.io}"
 # Azure Kubernetes Service
 ###############################################################################
 export AKS_CLUSTER="${AKS_CLUSTER:-aks-tsm-signing-demo}"
-export AKS_RG="${AKS_RG:-rg-tsm-signing}"
-export AKS_LOCATION="${AKS_LOCATION:-westus2}"
+export AKS_RG="${AKS_RG:-${DEMO_RG}}"
+export AKS_LOCATION="${AKS_LOCATION:-${DEMO_LOCATION}}"
 
 ###############################################################################
 # Azure Trusted Signing
 ###############################################################################
 export TS_ACCOUNT_NAME="${TS_ACCOUNT_NAME:-sig-tsm-demo}"
-export TS_RG="${TS_RG:-rg-tsm-signing}"
-export TS_LOCATION="${TS_LOCATION:-westus2}"
+export TS_RG="${TS_RG:-${DEMO_RG}}"
+export TS_LOCATION="${TS_LOCATION:-${DEMO_LOCATION}}"
 export TS_SKU="${TS_SKU:-Basic}"
 export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-demo}"
 

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -57,8 +57,8 @@ export TS_SKU="${TS_SKU:-Basic}"
 export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-kueu26-demo}"
 
 # Certificate profile subject DN fields
-export TS_COMMON_NAME="${TS_COMMON_NAME:-microsoft.onmicrosoft.com}"
-export TS_ORGANIZATION="${TS_ORGANIZATION:-microsoft.onmicrosoft.com}"
+export TS_COMMON_NAME="${TS_COMMON_NAME:-toddysmlive.onmicrosoft.com}"
+export TS_ORGANIZATION="${TS_ORGANIZATION:-toddysmlive.onmicrosoft.com}"
 export TS_ORG_UNIT="${TS_ORG_UNIT:-Cloud Native Security and Registries}"
 export TS_CITY="${TS_CITY:-Redmond}"
 export TS_STATE="${TS_STATE:-Washington}"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -9,6 +9,11 @@
 #   export ACR_NAME=myacr
 #   ./setup-acr.sh
 #
+# To skip the interactive tenant/subscription prompts, export them upfront:
+#   export DEMO_TENANT_ID=<tenant-id>
+#   export DEMO_SUBSCRIPTION_ID=<subscription-id>
+#   ./setup-acr.sh
+#
 # Source from a setup script:
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   source "${SCRIPT_DIR}/defaults.sh"
@@ -22,6 +27,8 @@
 ###############################################################################
 export DEMO_RG="${DEMO_RG:-rg-tsm-kubeconeu2026-demo}"
 export DEMO_LOCATION="${DEMO_LOCATION:-westus2}"
+export DEMO_TENANT_ID="${DEMO_TENANT_ID:-}"
+export DEMO_SUBSCRIPTION_ID="${DEMO_SUBSCRIPTION_ID:-}"
 
 ###############################################################################
 # Azure Container Registry
@@ -70,12 +77,24 @@ export TS_TSA_ROOT_CERT="${TS_TSA_ROOT_CERT:-http://www.microsoft.com/pkiops/cer
 ###############################################################################
 echo "[INFO] Logging out of Azure CLI to ensure a clean session..."
 az logout --verbose 2>/dev/null || true
-echo "[INFO] Logging in to Azure CLI..."
-az login
+
+# Prompt for tenant and subscription if not already set
+if [[ -z "$DEMO_TENANT_ID" ]]; then
+    read -rp "Enter Azure Tenant ID: " DEMO_TENANT_ID
+fi
+if [[ -z "$DEMO_SUBSCRIPTION_ID" ]]; then
+    read -rp "Enter Azure Subscription ID: " DEMO_SUBSCRIPTION_ID
+fi
+
+echo "[INFO] Logging in to Azure CLI (tenant: $DEMO_TENANT_ID)..."
+az login --tenant "$DEMO_TENANT_ID"
 if ! az account show --query id -o tsv &>/dev/null; then
     echo "[ERROR] No active Azure CLI session after login. Exiting." >&2
     exit 1
 fi
+
+echo "[INFO] Setting active subscription to '$DEMO_SUBSCRIPTION_ID'..."
+az account set --subscription "$DEMO_SUBSCRIPTION_ID"
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SUBSCRIPTION=$(az account show --query name -o tsv)
 echo "[INFO] Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -1,0 +1,56 @@
+# defaults.sh
+#
+# Shared default configuration for the KubeCon EU 2026 artifact-signing demo.
+# This file is meant to be sourced by the setup scripts — do not run directly.
+#
+# All values can be overridden by exporting environment variables before
+# running any setup script. Example:
+#
+#   export ACR_NAME=myacr
+#   ./setup-acr.sh
+#
+# Source from a setup script:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "${SCRIPT_DIR}/defaults.sh"
+
+###############################################################################
+# Azure Container Registry
+###############################################################################
+export ACR_NAME="${ACR_NAME:-acrtsmpremiumsku}"
+export ACR_RG="${ACR_RG:-rg-tsm-signing}"
+export ACR_SKU="${ACR_SKU:-Premium}"
+export ACR_LOCATION="${ACR_LOCATION:-westus2}"
+# Derived from ACR_NAME — override explicitly if using a custom login server
+export ACR_LOGIN_SERVER="${ACR_LOGIN_SERVER:-${ACR_NAME}.azurecr.io}"
+
+###############################################################################
+# Azure Kubernetes Service
+###############################################################################
+export AKS_CLUSTER="${AKS_CLUSTER:-aks-tsm-signing-demo}"
+export AKS_RG="${AKS_RG:-rg-tsm-signing}"
+export AKS_LOCATION="${AKS_LOCATION:-westus2}"
+
+###############################################################################
+# Azure Trusted Signing
+###############################################################################
+export TS_ACCOUNT_NAME="${TS_ACCOUNT_NAME:-sig-tsm-demo}"
+export TS_RG="${TS_RG:-rg-tsm-signing}"
+export TS_LOCATION="${TS_LOCATION:-westus2}"
+export TS_SKU="${TS_SKU:-Basic}"
+export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-demo}"
+
+# Certificate profile subject DN fields
+export TS_COMMON_NAME="${TS_COMMON_NAME:-microsoft.onmicrosoft.com}"
+export TS_ORGANIZATION="${TS_ORGANIZATION:-microsoft.onmicrosoft.com}"
+export TS_ORG_UNIT="${TS_ORG_UNIT:-Cloud Native Security and Registries}"
+export TS_CITY="${TS_CITY:-Redmond}"
+export TS_STATE="${TS_STATE:-Washington}"
+export TS_COUNTRY="${TS_COUNTRY:-US}"
+
+# Assembled certificate subject DN — derived from DN fields above.
+# Override explicitly if you need a different format.
+export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-CN=${TS_COMMON_NAME}, O=${TS_ORGANIZATION}, OU=${TS_ORG_UNIT}, L=${TS_CITY}, S=${TS_STATE}, C=${TS_COUNTRY}}"
+
+# Microsoft PKI certificate URLs (used by Ratify CertificateStore)
+export TS_SIGNING_ROOT_CERT="${TS_SIGNING_ROOT_CERT:-https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt}"
+export TS_TSA_ROOT_CERT="${TS_TSA_ROOT_CERT:-http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt}"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -26,7 +26,7 @@ export DEMO_LOCATION="${DEMO_LOCATION:-westus2}"
 ###############################################################################
 # Azure Container Registry
 ###############################################################################
-export ACR_NAME="${ACR_NAME:-tsmkubeconeu2026demo}"
+export ACR_NAME="${ACR_NAME:-acrtsmkubeconeu2026demo}"
 export ACR_RG="${ACR_RG:-${DEMO_RG}}"
 export ACR_SKU="${ACR_SKU:-Premium}"
 export ACR_LOCATION="${ACR_LOCATION:-${DEMO_LOCATION}}"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -66,6 +66,21 @@ export TS_SIGNING_ROOT_CERT="${TS_SIGNING_ROOT_CERT:-https://www.microsoft.com/p
 export TS_TSA_ROOT_CERT="${TS_TSA_ROOT_CERT:-http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt}"
 
 ###############################################################################
+# Log out and log back in to ensure a clean session on the correct subscription
+###############################################################################
+echo "[INFO] Logging out of Azure CLI to ensure a clean session..."
+az logout --verbose 2>/dev/null || true
+echo "[INFO] Logging in to Azure CLI..."
+az login
+if ! az account show --query id -o tsv &>/dev/null; then
+    echo "[ERROR] No active Azure CLI session after login. Exiting." >&2
+    exit 1
+fi
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+SUBSCRIPTION=$(az account show --query name -o tsv)
+echo "[INFO] Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
+
+###############################################################################
 # Ensure the shared resource group exists
 # This runs automatically when defaults.sh is sourced, so each setup script
 # doesn't need its own resource group creation step.

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -50,11 +50,11 @@ export AKS_LOCATION="${AKS_LOCATION:-${DEMO_LOCATION}}"
 ###############################################################################
 # Azure Trusted Signing
 ###############################################################################
-export TS_ACCOUNT_NAME="${TS_ACCOUNT_NAME:-sig-tsm-kubecon-eu-2026-demo}"
+export TS_ACCOUNT_NAME="${TS_ACCOUNT_NAME:-sig-tsm-kueu26-demo}"
 export TS_RG="${TS_RG:-${DEMO_RG}}"
 export TS_LOCATION="${TS_LOCATION:-${DEMO_LOCATION}}"
 export TS_SKU="${TS_SKU:-Basic}"
-export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-kubecon-eu-2026-demo}"
+export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-kueu26-demo}"
 
 # Certificate profile subject DN fields
 export TS_COMMON_NAME="${TS_COMMON_NAME:-microsoft.onmicrosoft.com}"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -46,6 +46,9 @@ export ACR_LOGIN_SERVER="${ACR_LOGIN_SERVER:-${ACR_NAME}.azurecr.io}"
 export AKS_CLUSTER="${AKS_CLUSTER:-aks-tsm-kubecon-eu-2026-demo}"
 export AKS_RG="${AKS_RG:-${DEMO_RG}}"
 export AKS_LOCATION="${AKS_LOCATION:-${DEMO_LOCATION}}"
+# User-assigned managed identity used by Ratify to pull reference artifacts
+# (signatures, SBOMs) from ACR via workload identity federation.
+export RATIFY_MI_NAME="${RATIFY_MI_NAME:-ratify-mi}"
 
 ###############################################################################
 # Azure Trusted Signing

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -26,7 +26,7 @@ export DEMO_LOCATION="${DEMO_LOCATION:-westus2}"
 ###############################################################################
 # Azure Container Registry
 ###############################################################################
-export ACR_NAME="${ACR_NAME:-acrtsmpremiumsku}"
+export ACR_NAME="${ACR_NAME:-tsmkubeconeu2026demo}"
 export ACR_RG="${ACR_RG:-${DEMO_RG}}"
 export ACR_SKU="${ACR_SKU:-Premium}"
 export ACR_LOCATION="${ACR_LOCATION:-${DEMO_LOCATION}}"
@@ -36,18 +36,18 @@ export ACR_LOGIN_SERVER="${ACR_LOGIN_SERVER:-${ACR_NAME}.azurecr.io}"
 ###############################################################################
 # Azure Kubernetes Service
 ###############################################################################
-export AKS_CLUSTER="${AKS_CLUSTER:-aks-tsm-signing-demo}"
+export AKS_CLUSTER="${AKS_CLUSTER:-aks-tsm-kubecon-eu-2026-demo}"
 export AKS_RG="${AKS_RG:-${DEMO_RG}}"
 export AKS_LOCATION="${AKS_LOCATION:-${DEMO_LOCATION}}"
 
 ###############################################################################
 # Azure Trusted Signing
 ###############################################################################
-export TS_ACCOUNT_NAME="${TS_ACCOUNT_NAME:-sig-tsm-demo}"
+export TS_ACCOUNT_NAME="${TS_ACCOUNT_NAME:-sig-tsm-kubecon-eu-2026-demo}"
 export TS_RG="${TS_RG:-${DEMO_RG}}"
 export TS_LOCATION="${TS_LOCATION:-${DEMO_LOCATION}}"
 export TS_SKU="${TS_SKU:-Basic}"
-export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-demo}"
+export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-kubecon-eu-2026-demo}"
 
 # Certificate profile subject DN fields
 export TS_COMMON_NAME="${TS_COMMON_NAME:-microsoft.onmicrosoft.com}"
@@ -64,3 +64,14 @@ export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-CN=${TS_COMMON_NAME}, O=${TS_ORGANIZA
 # Microsoft PKI certificate URLs (used by Ratify CertificateStore)
 export TS_SIGNING_ROOT_CERT="${TS_SIGNING_ROOT_CERT:-https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt}"
 export TS_TSA_ROOT_CERT="${TS_TSA_ROOT_CERT:-http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt}"
+
+###############################################################################
+# Ensure the shared resource group exists
+# This runs automatically when defaults.sh is sourced, so each setup script
+# doesn't need its own resource group creation step.
+###############################################################################
+if ! az group show --name "$DEMO_RG" &>/dev/null; then
+    echo "[INFO] Resource group '$DEMO_RG' not found — creating in '$DEMO_LOCATION'..."
+    az group create --name "$DEMO_RG" --location "$DEMO_LOCATION" --output none
+    echo "[INFO] Resource group '$DEMO_RG' created."
+fi

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/defaults.sh
@@ -56,17 +56,14 @@ export TS_LOCATION="${TS_LOCATION:-${DEMO_LOCATION}}"
 export TS_SKU="${TS_SKU:-Basic}"
 export TS_CERT_PROFILE="${TS_CERT_PROFILE:-cert-tsm-kueu26-demo}"
 
-# Certificate profile subject DN fields
-export TS_COMMON_NAME="${TS_COMMON_NAME:-toddysmlive.onmicrosoft.com}"
-export TS_ORGANIZATION="${TS_ORGANIZATION:-toddysmlive.onmicrosoft.com}"
-export TS_ORG_UNIT="${TS_ORG_UNIT:-Cloud Native Security and Registries}"
-export TS_CITY="${TS_CITY:-Redmond}"
-export TS_STATE="${TS_STATE:-Washington}"
-export TS_COUNTRY="${TS_COUNTRY:-US}"
+# Identity validation ID — required for certificate profile creation.
+# Find it in the Portal: Trusted Signing → <account> → Identity validation
+# The GUID is shown in the identity validation details.
+export TS_IDENTITY_VALIDATION_ID="${TS_IDENTITY_VALIDATION_ID:-}"
 
-# Assembled certificate subject DN — derived from DN fields above.
-# Override explicitly if you need a different format.
-export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-CN=${TS_COMMON_NAME}, O=${TS_ORGANIZATION}, OU=${TS_ORG_UNIT}, L=${TS_CITY}, S=${TS_STATE}, C=${TS_COUNTRY}}"
+# Certificate subject DN — used for display / Ratify policy only (not passed
+# to the CLI; the subject is derived from the identity validation at signing time).
+export TS_CERT_SUBJECT="${TS_CERT_SUBJECT:-}"
 
 # Microsoft PKI certificate URLs (used by Ratify CertificateStore)
 export TS_SIGNING_ROOT_CERT="${TS_SIGNING_ROOT_CERT:-https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt}"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -69,27 +69,6 @@ rm -f msft-root-certificate-authority-2020.crt msft-tsa-root-certificate-authori
 kubectl delete -f nginx-signed-demo.yaml --ignore-not-found
 kubectl delete -f nginx-unsigned-demo.yaml --ignore-not-found
 
-# Delete all referrers (signatures) attached to the signed image
-_signed_image="acrtsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed"
-echo "[INFO] Deleting referrers for $_signed_image..."
-az acr login --name acrtsmkubeconeu2026demo 2>/dev/null || true
-_digests=$(oras discover --format json "$_signed_image" 2>/dev/null \
-    | python3 -c "import json,sys; [print(m['digest']) for m in json.load(sys.stdin).get('manifests',[])]" 2>/dev/null)
-if [[ -z "$_digests" ]]; then
-    echo "[INFO] No referrers found for $_signed_image."
-else
-    while IFS= read -r _digest; do
-        [[ -z "$_digest" ]] && continue
-        echo "[INFO]   Deleting referrer: $_digest"
-        az acr manifest delete \
-            --name "nginx@${_digest}" \
-            --registry "acrtsmkubeconeu2026demo" \
-            --yes || true
-    done <<< "$_digests"
-    echo "[INFO] Referrer cleanup complete."
-fi
-
-
 # hide the evidence
 clear
 

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -117,7 +117,7 @@ pe "# Set up variables for signature verification"
 pe "TS_TSA_ROOT_CERT=\"http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt\""
 pe "SIGNING_TRUST_STORE=kubeconDemoSigningRootCerts"
 pe "TSA_TRUST_STORE=kubeconDemoTsaRootCerts"
-pe "TS_CERT_SUBJECT=\"CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052\""
+pe "TS_CERT_SUBJECT=\"CN=toddysmlive.onmicrosoft.com,OU=Cloud Native Security and Registries,O=toddysmlive.onmicrosoft.com,L=Redmond,ST=Washington,C=US\""
 
 echo
 wait

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -10,7 +10,7 @@
 #
 # pass -h to see all options
 #################################
-. ../demo-magic.sh -d
+. ../demo-magic.sh -n
 
 
 ########################
@@ -20,7 +20,7 @@
 #
 # speed at which to simulate typing. bigger num = faster
 #
-TYPE_SPEED=20
+TYPE_SPEED=100
 
 #
 # custom prompt
@@ -34,12 +34,17 @@ DEMO_PROMPT="${GREEN}$ ${COLOR_RESET}"
 # DEMO_CMD_COLOR=$BLACK
 
 # clean up any previous runs
+SIGNING_TRUST_STORE=kubeconDemoSigningRootCerts
+TSA_TRUST_STORE=kubeconDemoTsaRootCerts
 notation plugin uninstall azure-artifactsigning --yes
 notation cert delete --type ca --store $SIGNING_TRUST_STORE --all --yes
 notation cert delete --type tsa --store $TSA_TRUST_STORE --all --yes
 rm -f ~/.config/notation/trustpolicy.json
+rm -f ~/Library/Application\ Support/notation/trustpolicy.json
 rm -f msft-root-certificate-authority-2020.crt msft-tsa-root-certificate-authority-2020.crt
-rm -fr ~/.config/notation
+kubectl delete -f nginx-signed-demo.yaml --ignore-not-found
+kubectl delete -f nginx-unsigned-demo.yaml --ignore-not-found
+
 
 # hide the evidence
 clear
@@ -59,12 +64,16 @@ pe "TS_TSA_URL=http://timestamp.acs.microsoft.com/"
 pe "TS_SIGNING_ROOT_CERT=\"https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt\""
 
 echo
+wait
+
 pe "# Set up variables for ACR and image"
 pe "ACR_LOGIN_SERVER=acrtsmpremiumsku.azurecr.io"
 pe "REPOSITORY=python"
-pe "IMAGE=acrtsmpremiumsku.azurecr.io/python:3.13"
+pe "SIGNED_IMAGE=acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed"
 
 echo
+wait
+
 pe "# Set up variables for signature verification"
 pe "TS_TSA_ROOT_CERT=\"http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt\""
 pe "SIGNING_TRUST_STORE=kubeconDemoSigningRootCerts"
@@ -72,6 +81,8 @@ pe "TSA_TRUST_STORE=kubeconDemoTsaRootCerts"
 pe "TS_CERT_SUBJECT=\"CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=Cloud Native Security and Registries, L=Redmond, S=Washington, C=US\""
 
 echo
+wait
+
 pe "# Log in to ACR"
 pe "az login"
 pe "az acr login --name $ACR_LOGIN_SERVER"
@@ -85,6 +96,8 @@ pe "# Check the plugin"
 pe "notation plugin ls"
 
 echo
+wait
+
 pe "# Install the plugin"
 pe "notation plugin install --url https://github.com/Azure/artifact-signing-notation-plugin/releases/download/v1.1.0/notation-azure-artifactsigning_1.1.0_darwin_arm64.tar.gz --sha256sum f9ff085c86474b2371cf3acd70e24f067df2f5c2c3240e101957d99b55d480f0"
 
@@ -93,32 +106,42 @@ pe "# List the plugin"
 pe "notation plugin ls"
 
 echo
+wait
+
 pe "# Download the TSA root certificate"
 pe "curl -o msft-tsa-root-certificate-authority-2020.crt $TS_TSA_ROOT_CERT"
 
 echo
 pe "# Sign the container image"
-pe "notation sign --signature-format cose --timestamp-url $TS_TSA_URL --timestamp-root-cert "msft-tsa-root-certificate-authority-2020.crt" --id $TS_CERT_PROFILE --plugin azure-artifactsigning --plugin-config accountName=$TS_ACCT_NAME --plugin-config baseUrl=$TS_ACCT_URL --plugin-config certProfile=$TS_CERT_PROFILE $IMAGE"
+pe "notation sign --signature-format cose --timestamp-url $TS_TSA_URL --timestamp-root-cert "msft-tsa-root-certificate-authority-2020.crt" --id $TS_CERT_PROFILE --plugin azure-artifactsigning --plugin-config accountName=$TS_ACCT_NAME --plugin-config baseUrl=$TS_ACCT_URL --plugin-config certProfile=$TS_CERT_PROFILE $SIGNED_IMAGE"
 
 echo
+wait
+
 pe "# List the signature"
-pe "notation ls $IMAGE"
+pe "notation ls $SIGNED_IMAGE"
 
 echo
+wait
+
 pe "# Inpsect the signature"
-pe "notation inspect $IMAGE"
+pe "notation inspect $SIGNED_IMAGE"
 
 echo
+wait
+
 pe "# Set up trust store"
 pe "curl -o msft-root-certificate-authority-2020.crt $TS_SIGNING_ROOT_CERT"
 pe "notation cert add --type ca --store $SIGNING_TRUST_STORE msft-root-certificate-authority-2020.crt"
 pe "notation cert add -t tsa -s $TSA_TRUST_STORE msft-tsa-root-certificate-authority-2020.crt"
 
 echo
-pe "# List the trust store"
+pe "# List the trust stores"
 pe "notation cert ls"
 
 echo
+wait
+
 pe "# Set up trust policy"
 pe "notation policy import trustpolicy.json"
 
@@ -127,12 +150,24 @@ pe "# Show trust policy"
 pe "notation policy show"
 
 echo
+wait
+
 pe "# Verify the image"
-pe "notation verify $IMAGE"
+pe "notation verify $SIGNED_IMAGE"
 
-# run command behind
+echo
+wait 
 
-# enters interactive mode and allows newly typed command to be executed
+pe "# Let's deploy a demo application using the signed image"
+pe "kubectl get all --namespace default"
+pe "kubectl apply -f nginx-signed-demo.yaml"
+pe "kubectl get svc nginx-signed-demo -w"
+
+echo
+wait
+
+pe "# Now let's try to deploy an unsigned image and see it get blocked by the policy"
+pe "kubectl apply -f nginx-unsigned-demo.yaml"
 
 # show a prompt so as not to reveal our true nature after
 # the demo has concluded

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -33,6 +33,30 @@ DEMO_PROMPT="${GREEN}$ ${COLOR_RESET}"
 # text color
 # DEMO_CMD_COLOR=$BLACK
 
+# Log in to Azure
+echo "[INFO] Logging out of Azure CLI to ensure a clean session..."
+az logout --verbose 2>/dev/null || true
+
+if [[ -z "$DEMO_TENANT_ID" ]]; then
+    read -rp "Enter Azure Tenant ID: " DEMO_TENANT_ID
+fi
+if [[ -z "$DEMO_SUBSCRIPTION_ID" ]]; then
+    read -rp "Enter Azure Subscription ID: " DEMO_SUBSCRIPTION_ID
+fi
+
+echo "[INFO] Logging in to Azure CLI (tenant: $DEMO_TENANT_ID)..."
+az login --tenant "$DEMO_TENANT_ID"
+if ! az account show --query id -o tsv &>/dev/null; then
+    echo "[ERROR] No active Azure CLI session after login. Exiting." >&2
+    exit 1
+fi
+
+echo "[INFO] Setting active subscription to '$DEMO_SUBSCRIPTION_ID'..."
+az account set --subscription "$DEMO_SUBSCRIPTION_ID"
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+SUBSCRIPTION=$(az account show --query name -o tsv)
+echo "[INFO] Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
+
 # clean up any previous runs
 SIGNING_TRUST_STORE=kubeconDemoSigningRootCerts
 TSA_TRUST_STORE=kubeconDemoTsaRootCerts

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -70,19 +70,24 @@ kubectl delete -f nginx-signed-demo.yaml --ignore-not-found
 kubectl delete -f nginx-unsigned-demo.yaml --ignore-not-found
 
 # Delete all referrers (signatures) attached to the signed image
-echo "[INFO] Deleting referrers for acrtsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed..."
-az acr manifest list-referrers \
-    --name "nginx:1.29-alpine-signed" \
-    --registry "acrtsmkubeconeu2026demo" \
-    --query "[].digest" -o tsv 2>/dev/null | \
-while read -r _digest; do
-    [[ -z "$_digest" ]] && continue
-    echo "[INFO]   Deleting referrer: $_digest"
-    az acr manifest delete \
-        --name "nginx@${_digest}" \
-        --registry "acrtsmkubeconeu2026demo" \
-        --yes 2>/dev/null || true
-done
+_signed_image="acrtsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed"
+echo "[INFO] Deleting referrers for $_signed_image..."
+az acr login --name acrtsmkubeconeu2026demo 2>/dev/null || true
+_digests=$(oras discover --format json "$_signed_image" 2>/dev/null \
+    | python3 -c "import json,sys; [print(m['digest']) for m in json.load(sys.stdin).get('manifests',[])]" 2>/dev/null)
+if [[ -z "$_digests" ]]; then
+    echo "[INFO] No referrers found for $_signed_image."
+else
+    while IFS= read -r _digest; do
+        [[ -z "$_digest" ]] && continue
+        echo "[INFO]   Deleting referrer: $_digest"
+        az acr manifest delete \
+            --name "nginx@${_digest}" \
+            --registry "acrtsmkubeconeu2026demo" \
+            --yes || true
+    done <<< "$_digests"
+    echo "[INFO] Referrer cleanup complete."
+fi
 
 
 # hide the evidence

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -102,7 +102,7 @@ pe "# Set up variables for signature verification"
 pe "TS_TSA_ROOT_CERT=\"http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt\""
 pe "SIGNING_TRUST_STORE=kubeconDemoSigningRootCerts"
 pe "TSA_TRUST_STORE=kubeconDemoTsaRootCerts"
-pe "TS_CERT_SUBJECT=\"CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=Cloud Native Security and Registries, L=Redmond, S=Washington, C=US\""
+pe "TS_CERT_SUBJECT=\"CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052\""
 
 echo
 wait

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -57,9 +57,9 @@ cmd
 # Set up env variables
 
 pe "# Set up variables for Trusted Signing"
-pe "TS_ACCT_NAME=sig-tsm-kubecon-eu-2026-demo"
+pe "TS_ACCT_NAME=sig-tsm-kueu26-demo"
 pe "TS_ACCT_URL=https://wus2.codesigning.azure.net/"
-pe "TS_CERT_PROFILE=cert-tsm-kubecon-eu-2026-demo"
+pe "TS_CERT_PROFILE=cert-tsm-kueu26-demo"
 pe "TS_TSA_URL=http://timestamp.acs.microsoft.com/"
 pe "TS_SIGNING_ROOT_CERT=\"https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt\""
 

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -57,9 +57,9 @@ cmd
 # Set up env variables
 
 pe "# Set up variables for Trusted Signing"
-pe "TS_ACCT_NAME=sig-tsm-demo"
+pe "TS_ACCT_NAME=sig-tsm-kubecon-eu-2026-demo"
 pe "TS_ACCT_URL=https://wus2.codesigning.azure.net/"
-pe "TS_CERT_PROFILE=cert-tsm-demo"
+pe "TS_CERT_PROFILE=cert-tsm-kubecon-eu-2026-demo"
 pe "TS_TSA_URL=http://timestamp.acs.microsoft.com/"
 pe "TS_SIGNING_ROOT_CERT=\"https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt\""
 
@@ -67,9 +67,9 @@ echo
 wait
 
 pe "# Set up variables for ACR and image"
-pe "ACR_LOGIN_SERVER=acrtsmpremiumsku.azurecr.io"
+pe "ACR_LOGIN_SERVER=tsmkubeconeu2026demo.azurecr.io"
 pe "REPOSITORY=nginx"
-pe "SIGNED_IMAGE=acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed"
+pe "SIGNED_IMAGE=tsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed"
 
 echo
 wait

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -69,6 +69,21 @@ rm -f msft-root-certificate-authority-2020.crt msft-tsa-root-certificate-authori
 kubectl delete -f nginx-signed-demo.yaml --ignore-not-found
 kubectl delete -f nginx-unsigned-demo.yaml --ignore-not-found
 
+# Delete all referrers (signatures) attached to the signed image
+echo "[INFO] Deleting referrers for acrtsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed..."
+az acr manifest list-referrers \
+    --name "nginx:1.29-alpine-signed" \
+    --registry "acrtsmkubeconeu2026demo" \
+    --query "[].digest" -o tsv 2>/dev/null | \
+while read -r _digest; do
+    [[ -z "$_digest" ]] && continue
+    echo "[INFO]   Deleting referrer: $_digest"
+    az acr manifest delete \
+        --name "nginx@${_digest}" \
+        --registry "acrtsmkubeconeu2026demo" \
+        --yes 2>/dev/null || true
+done
+
 
 # hide the evidence
 clear

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -198,7 +198,12 @@ pe "# Now let's try to deploy an unsigned image and see it get blocked by the po
 pe "kubectl apply -f nginx-unsigned-demo.yaml"
 pe "kubectl get events -n default --sort-by='.lastTimestamp' | grep nginx-unsigned"
 
+echo
+wait
+pe "kubectl get pods -n default"
+
 # show a prompt so as not to reveal our true nature after
 # the demo has concluded
+p "echo 'Demo complete. You have successfully signed and verified a container image using Azure Trusted Signing and Notation!'"
 p ""
 wait

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -67,9 +67,9 @@ echo
 wait
 
 pe "# Set up variables for ACR and image"
-pe "ACR_LOGIN_SERVER=tsmkubeconeu2026demo.azurecr.io"
+pe "ACR_LOGIN_SERVER=acrtsmkubeconeu2026demo.azurecr.io"
 pe "REPOSITORY=nginx"
-pe "SIGNED_IMAGE=tsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed"
+pe "SIGNED_IMAGE=acrtsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed"
 
 echo
 wait

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -189,8 +189,14 @@ pe "kubectl get svc nginx-signed-demo -w"
 echo
 wait
 
+pe "kubectl get events -n default --sort-by='.lastTimestamp' | grep nginx-signed"
+
+echo
+wait
+
 pe "# Now let's try to deploy an unsigned image and see it get blocked by the policy"
 pe "kubectl apply -f nginx-unsigned-demo.yaml"
+pe "kubectl get events -n default --sort-by='.lastTimestamp' | grep nginx-unsigned"
 
 # show a prompt so as not to reveal our true nature after
 # the demo has concluded

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/demo-trusted-signing.sh
@@ -68,7 +68,7 @@ wait
 
 pe "# Set up variables for ACR and image"
 pe "ACR_LOGIN_SERVER=acrtsmpremiumsku.azurecr.io"
-pe "REPOSITORY=python"
+pe "REPOSITORY=nginx"
 pe "SIGNED_IMAGE=acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed"
 
 echo

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-signed-demo.yaml
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-signed-demo.yaml
@@ -103,11 +103,11 @@ data:
         <div class="info-grid">
           <div class="info-row">
             <span class="info-label">Image</span>
-            <span class="info-value">acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed</span>
+            <span class="info-value">acrtsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed</span>
           </div>
           <div class="info-row">
             <span class="info-label">Signer</span>
-            <span class="info-value">Azure Trusted Signing — cert-tsm-demo</span>
+            <span class="info-value">Azure Trusted Signing — cert-tsm-kueu26-demo</span>
           </div>
           <div class="info-row">
             <span class="info-label">Policy Engine</span>

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-signed-demo.yaml
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-signed-demo.yaml
@@ -1,0 +1,187 @@
+---
+# ConfigMap — custom HTML page served by NGINX
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-demo-html
+  namespace: default
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>KubeCon EU 2026 — Artifact Signing Demo</title>
+      <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+          background: #0a0e1a;
+          color: #e8eaf0;
+          min-height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 2rem;
+        }
+        .card {
+          background: #111827;
+          border: 1px solid #1e3a5f;
+          border-radius: 12px;
+          padding: 3rem 3.5rem;
+          max-width: 640px;
+          width: 100%;
+          box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+        }
+        .badge {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.4rem;
+          background: #0d2137;
+          border: 1px solid #1a4b7a;
+          border-radius: 999px;
+          padding: 0.3rem 0.85rem;
+          font-size: 0.75rem;
+          color: #60a5fa;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          margin-bottom: 1.5rem;
+        }
+        .badge::before { content: "●"; color: #22c55e; }
+        h1 {
+          font-size: 1.75rem;
+          font-weight: 700;
+          line-height: 1.2;
+          margin-bottom: 0.75rem;
+          color: #f1f5f9;
+        }
+        h1 span { color: #3b82f6; }
+        .subtitle {
+          color: #94a3b8;
+          font-size: 0.95rem;
+          margin-bottom: 2rem;
+          line-height: 1.6;
+        }
+        .info-grid {
+          display: grid;
+          gap: 0.75rem;
+          margin-bottom: 2rem;
+        }
+        .info-row {
+          display: grid;
+          grid-template-columns: 140px 1fr;
+          gap: 0.5rem;
+          align-items: start;
+          padding: 0.6rem 0.75rem;
+          background: #0d1626;
+          border-radius: 6px;
+          font-size: 0.85rem;
+        }
+        .info-label { color: #64748b; font-weight: 600; }
+        .info-value { color: #e2e8f0; word-break: break-all; font-family: monospace; font-size: 0.8rem; }
+        .status-ok { color: #22c55e; font-weight: 700; font-family: inherit; font-size: 0.85rem; }
+        .footer {
+          font-size: 0.75rem;
+          color: #475569;
+          border-top: 1px solid #1e293b;
+          padding-top: 1.25rem;
+          line-height: 1.6;
+        }
+        .footer a { color: #3b82f6; text-decoration: none; }
+      </style>
+    </head>
+    <body>
+      <div class="card">
+        <div class="badge">Signature Verified</div>
+        <h1>Artifact Signing with <span>Azure Trusted Signing</span></h1>
+        <p class="subtitle">
+          This pod was admitted by Kubernetes only because its image carries a valid
+          Notation signature issued by Azure Trusted Signing and verified by Ratify
+          + OPA Gatekeeper.
+        </p>
+        <div class="info-grid">
+          <div class="info-row">
+            <span class="info-label">Image</span>
+            <span class="info-value">acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Signer</span>
+            <span class="info-value">Azure Trusted Signing — cert-tsm-demo</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Policy Engine</span>
+            <span class="info-value">OPA Gatekeeper + Ratify (Notation verifier)</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Admission</span>
+            <span class="status-ok">✔ ALLOWED — signature valid</span>
+          </div>
+        </div>
+        <div class="footer">
+          Demonstrated at <strong>KubeCon EU 2026</strong> ·
+          <a href="https://github.com/toddysm/cssc-pipeline">github.com/toddysm/cssc-pipeline</a>
+        </div>
+      </div>
+    </body>
+    </html>
+---
+# Deployment — signed NGINX image with custom HTML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-signed-demo
+  namespace: default
+  labels:
+    app: nginx-signed-demo
+    demo: kubecon-eu-2026
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-signed-demo
+  template:
+    metadata:
+      labels:
+        app: nginx-signed-demo
+        demo: kubecon-eu-2026
+    spec:
+      containers:
+        - name: nginx
+          image: acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - name: html
+              mountPath: /usr/share/nginx/html
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+      volumes:
+        - name: html
+          configMap:
+            name: nginx-demo-html
+---
+# Service — expose NGINX to the internet via Azure Load Balancer
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-signed-demo
+  namespace: default
+  labels:
+    app: nginx-signed-demo
+    demo: kubecon-eu-2026
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-signed-demo
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-signed-demo.yaml
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-signed-demo.yaml
@@ -148,7 +148,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed
+          image: acrtsmkubeconeu2026demo.azurecr.io/nginx:1.29-alpine-signed
           ports:
             - containerPort: 80
               protocol: TCP

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-unsigned-demo.yaml
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-unsigned-demo.yaml
@@ -10,7 +10,7 @@
 # Expected output (admission webhook denial):
 #   Error from server (Forbidden): admission webhook "validation.gatekeeper.sh"
 #   denied the request: [require-notation-signature] Signature verification
-#   failed for image acrtsmpremiumsku.azurecr.io/nginx:1.28-alpine-unsigned: ...
+#   failed for image acrtsmkubeconeu2026demo.azurecr.io/nginx:1.28-alpine-unsigned: ...
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-unsigned-demo.yaml
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-unsigned-demo.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: acrtsmpremiumsku.azurecr.io/nginx:1.28-alpine-unsigned
+          image: acrtsmkubeconeu2026demo.azurecr.io/nginx:1.28-alpine-unsigned
           ports:
             - containerPort: 80
               protocol: TCP

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-unsigned-demo.yaml
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/nginx-unsigned-demo.yaml
@@ -1,0 +1,45 @@
+---
+# Deployment — UNSIGNED NGINX image
+#
+# This deployment is intentionally rejected by Gatekeeper + Ratify because the
+# image has no Notation signature.  Apply it to demonstrate that the admission
+# policy blocks unsigned workloads:
+#
+#   kubectl apply -f nginx-unsigned-demo.yaml
+#
+# Expected output (admission webhook denial):
+#   Error from server (Forbidden): admission webhook "validation.gatekeeper.sh"
+#   denied the request: [require-notation-signature] Signature verification
+#   failed for image acrtsmpremiumsku.azurecr.io/nginx:1.28-alpine-unsigned: ...
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-unsigned-demo
+  namespace: default
+  labels:
+    app: nginx-unsigned-demo
+    demo: kubecon-eu-2026
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-unsigned-demo
+  template:
+    metadata:
+      labels:
+        app: nginx-unsigned-demo
+        demo: kubecon-eu-2026
+    spec:
+      containers:
+        - name: nginx
+          image: acrtsmpremiumsku.azurecr.io/nginx:1.28-alpine-unsigned
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
@@ -64,40 +64,9 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Log out and log back in to ensure the correct subscription
+# Step 1 — Create Azure Container Registry
 ###############################################################################
-info "Step 1: Logging out of Azure CLI to ensure a clean session..."
-az logout --verbose 2>/dev/null || true
-info "Logging in to Azure CLI..."
-az login
-if ! az account show --query id -o tsv &>/dev/null; then
-    error "No active Azure CLI session. Authenticate first with one of:"
-    error "  az login                                  (interactive)"
-    error "  az login --service-principal ...          (service principal)"
-    error "  az login --identity                       (managed identity)"
-    exit 1
-fi
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-SUBSCRIPTION=$(az account show --query name -o tsv)
-info "Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
-
-###############################################################################
-# Step 2 — Create resource group
-###############################################################################
-info "Step 2: Ensuring resource group '$ACR_RG' exists..."
-if az group show --name "$ACR_RG" &>/dev/null; then
-    info "Resource group '$ACR_RG' already exists — skipping."
-else
-    run az group create \
-        --name "$ACR_RG" \
-        --location "$ACR_LOCATION"
-    info "Resource group '$ACR_RG' created."
-fi
-
-###############################################################################
-# Step 3 — Create Azure Container Registry
-###############################################################################
-info "Step 3: Creating ACR '$ACR_NAME' (SKU: $ACR_SKU)..."
+info "Step 1: Creating ACR '$ACR_NAME' (SKU: $ACR_SKU)..."
 if az acr show --name "$ACR_NAME" --resource-group "$ACR_RG" &>/dev/null; then
     info "ACR '$ACR_NAME' already exists — skipping."
 else
@@ -110,15 +79,15 @@ else
 fi
 
 ###############################################################################
-# Step 4 — Log in to ACR
+# Step 2 — Log in to ACR
 ###############################################################################
-info "Step 4: Logging in to ACR '$ACR_LOGIN_SERVER'..."
+info "Step 2: Logging in to ACR '$ACR_LOGIN_SERVER'..."
 run az acr login --name "$ACR_NAME"
 
 ###############################################################################
-# Step 5 — Copy images using ORAS
+# Step 3 — Copy images using ORAS
 ###############################################################################
-info "Step 5: Copying images from Docker Hub into '$ACR_LOGIN_SERVER'..."
+info "Step 3: Copying images from Docker Hub into '$ACR_LOGIN_SERVER'..."
 
 # nginx:1.29-alpine → <acr>/nginx:1.29-alpine-signed (will be Notation-signed later)
 info "  Copying nginx:1.29-alpine → ${ACR_LOGIN_SERVER}/nginx:1.29-alpine-signed"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# setup-acr.sh
+#
+# Creates an Azure Container Registry and copies the demo NGINX images into it
+# from Docker Hub using ORAS, retagging them for the demo:
+#
+#   nginx:1.29-alpine  →  <acr>/nginx:1.29-alpine-signed
+#   nginx:1.28-alpine  →  <acr>/nginx:1.28-alpine-unsigned
+#
+# Usage:
+#   chmod +x setup-acr.sh
+#   ./setup-acr.sh
+#
+# Required environment variables:
+#   ACR_NAME   - Name of the ACR to create (e.g. acrtsmpremiumsku)
+#   ACR_RG     - Resource group for the ACR
+#   ACR_SKU    - ACR SKU (default: Premium)
+#   ACR_LOCATION - Azure region (default: westus2)
+
+set -euo pipefail
+
+###############################################################################
+# Colors / helpers
+###############################################################################
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+cmd_log() { echo -e "${CYAN}[CMD]${NC} $*"; }
+
+run() {
+    cmd_log "$*"
+    local _err; _err=$(mktemp)
+    if ! "$@" 2>"$_err"; then
+        local _rc=$?
+        [[ -s "$_err" ]] && error "$(cat "$_err")"
+        rm -f "$_err"
+        return $_rc
+    fi
+    rm -f "$_err"
+}
+
+###############################################################################
+# Load shared defaults (override by exporting before running)
+###############################################################################
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=defaults.sh
+source "${SCRIPT_DIR}/defaults.sh"
+
+###############################################################################
+# Validate required variables
+###############################################################################
+REQUIRED_VARS=(ACR_NAME ACR_RG ACR_SKU ACR_LOCATION)
+for var in "${REQUIRED_VARS[@]}"; do
+    if [[ -z "${!var:-}" ]]; then
+        error "Required environment variable \$$var is not set."
+        exit 1
+    fi
+done
+
+###############################################################################
+# Step 1 — Verify Azure login
+###############################################################################
+info "Step 1: Verifying Azure login..."
+if ! az account show --query id -o tsv &>/dev/null; then
+    warn "Not logged in. Running az login..."
+    run az login
+fi
+SUBSCRIPTION=$(az account show --query name -o tsv)
+info "Using subscription: $SUBSCRIPTION"
+
+###############################################################################
+# Step 2 — Create resource group
+###############################################################################
+info "Step 2: Ensuring resource group '$ACR_RG' exists..."
+if az group show --name "$ACR_RG" &>/dev/null; then
+    info "Resource group '$ACR_RG' already exists — skipping."
+else
+    run az group create \
+        --name "$ACR_RG" \
+        --location "$ACR_LOCATION"
+    info "Resource group '$ACR_RG' created."
+fi
+
+###############################################################################
+# Step 3 — Create Azure Container Registry
+###############################################################################
+info "Step 3: Creating ACR '$ACR_NAME' (SKU: $ACR_SKU)..."
+if az acr show --name "$ACR_NAME" --resource-group "$ACR_RG" &>/dev/null; then
+    info "ACR '$ACR_NAME' already exists — skipping."
+else
+    run az acr create \
+        --name "$ACR_NAME" \
+        --resource-group "$ACR_RG" \
+        --location "$ACR_LOCATION" \
+        --sku "$ACR_SKU"
+    info "ACR '$ACR_NAME' created."
+fi
+
+###############################################################################
+# Step 4 — Log in to ACR
+###############################################################################
+info "Step 4: Logging in to ACR '$ACR_LOGIN_SERVER'..."
+run az acr login --name "$ACR_NAME"
+
+###############################################################################
+# Step 5 — Copy images using ORAS
+###############################################################################
+info "Step 5: Copying images from Docker Hub into '$ACR_LOGIN_SERVER'..."
+
+# nginx:1.29-alpine → <acr>/nginx:1.29-alpine-signed (will be Notation-signed later)
+info "  Copying nginx:1.29-alpine → ${ACR_LOGIN_SERVER}/nginx:1.29-alpine-signed"
+run oras copy \
+    registry-1.docker.io/library/nginx:1.29-alpine \
+    "${ACR_LOGIN_SERVER}/nginx:1.29-alpine-signed"
+
+# nginx:1.28-alpine → <acr>/nginx:1.28-alpine-unsigned (intentionally not signed)
+info "  Copying nginx:1.28-alpine → ${ACR_LOGIN_SERVER}/nginx:1.28-alpine-unsigned"
+run oras copy \
+    registry-1.docker.io/library/nginx:1.28-alpine \
+    "${ACR_LOGIN_SERVER}/nginx:1.28-alpine-unsigned"
+
+###############################################################################
+# Summary
+###############################################################################
+echo
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}  ACR setup complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo
+echo "  ACR:      $ACR_LOGIN_SERVER"
+echo "  Images:"
+echo "    ${ACR_LOGIN_SERVER}/nginx:1.29-alpine-signed   (ready to sign with Notation)"
+echo "    ${ACR_LOGIN_SERVER}/nginx:1.28-alpine-unsigned (intentionally unsigned)"
+echo
+echo "Next steps:"
+echo "  1. Sign the image:  notation sign ${ACR_LOGIN_SERVER}/nginx:1.29-alpine-signed"
+echo "  2. Run setup-aks.sh to configure the AKS cluster"
+echo

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
@@ -64,9 +64,12 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Verify Azure login
+# Step 1 — Log out and log back in to ensure the correct subscription
 ###############################################################################
-info "Step 1: Verifying Azure login..."
+info "Step 1: Logging out of Azure CLI to ensure a clean session..."
+az logout --verbose 2>/dev/null || true
+info "Logging in to Azure CLI..."
+az login
 if ! az account show --query id -o tsv &>/dev/null; then
     error "No active Azure CLI session. Authenticate first with one of:"
     error "  az login                                  (interactive)"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-acr.sh
@@ -68,11 +68,15 @@ done
 ###############################################################################
 info "Step 1: Verifying Azure login..."
 if ! az account show --query id -o tsv &>/dev/null; then
-    warn "Not logged in. Running az login..."
-    run az login
+    error "No active Azure CLI session. Authenticate first with one of:"
+    error "  az login                                  (interactive)"
+    error "  az login --service-principal ...          (service principal)"
+    error "  az login --identity                       (managed identity)"
+    exit 1
 fi
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SUBSCRIPTION=$(az account show --query name -o tsv)
-info "Using subscription: $SUBSCRIPTION"
+info "Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
 
 ###############################################################################
 # Step 2 — Create resource group

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -223,18 +223,24 @@ if kubectl get verifier verifier-notation -n gatekeeper-system &>/dev/null; then
     kubectl delete verifier verifier-notation -n gatekeeper-system
 fi
 
-# The Helm chart registers a ratify-mutation-provider ExternalData Provider CR
-# and an AssignMetadata CR even when mutationProvider.enable=false (server not
-# running). Delete both to prevent Gatekeeper's mutation webhook from trying to
-# reach a dead endpoint or resolve missing provider references.
+# The Helm chart registers mutation CRs even when mutationProvider.enable=false
+# (server not running). Delete them all to prevent Gatekeeper's mutation webhook
+# from trying to reach a dead endpoint or resolve missing provider references.
+# This includes: ExternalData Provider, AssignMetadata, and Assign CRs.
 if kubectl get provider ratify-mutation-provider -n gatekeeper-system &>/dev/null; then
     info "Removing ratify-mutation-provider ExternalData Provider CR (mutation not used)..."
     kubectl delete provider ratify-mutation-provider -n gatekeeper-system
 fi
 if kubectl get assignmetadata -n gatekeeper-system 2>/dev/null | grep -q ratify; then
-    info "Removing Ratify AssignMetadata CR (mutation not used)..."
+    info "Removing Ratify AssignMetadata CRs (mutation not used)..."
     kubectl delete assignmetadata -n gatekeeper-system -l app.kubernetes.io/name=ratify --ignore-not-found
 fi
+info "Removing Ratify Assign mutation CRs (mutation not used)..."
+kubectl delete assign \
+    mutate-cronjob-image mutate-cronjob-image-ephemeral mutate-cronjob-image-init \
+    mutate-pod-image mutate-pod-image-ephemeral mutate-pod-image-init \
+    mutate-workload-image mutate-workload-image-ephemeral mutate-workload-image-init \
+    --ignore-not-found
 
 ###############################################################################
 # Step 7 — Download root certificates and configure Ratify

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -79,9 +79,24 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Create the AKS cluster
+# Step 1 — Register required resource providers
 ###############################################################################
-info "Step 1: Creating AKS cluster '$AKS_CLUSTER' in resource group '$AKS_RG'..."
+info "Step 1: Registering required Azure resource providers..."
+for _rp in Microsoft.ContainerService Microsoft.ContainerRegistry; do
+    _state=$(az provider show --namespace "$_rp" --query "registrationState" -o tsv 2>/dev/null || echo "NotRegistered")
+    if [[ "$_state" == "Registered" ]]; then
+        info "  $_rp is already registered."
+    else
+        info "  Registering $_rp..."
+        run az provider register --namespace "$_rp" --wait
+        info "  $_rp registered."
+    fi
+done
+
+###############################################################################
+# Step 2 — Create the AKS cluster
+###############################################################################
+info "Step 2: Creating AKS cluster '$AKS_CLUSTER' in resource group '$AKS_RG'..."
 
 if az aks show --name "$AKS_CLUSTER" --resource-group "$AKS_RG" &>/dev/null; then
     info "Cluster '$AKS_CLUSTER' already exists — skipping creation."
@@ -119,9 +134,9 @@ if [[ "$_az_policy" == "true" ]]; then
 fi
 
 ###############################################################################
-# Step 2 — Grant kubelet identity AcrPull on the ACR
+# Step 3 — Grant kubelet identity AcrPull on the ACR
 ###############################################################################
-info "Step 2: Granting kubelet identity AcrPull on ACR '$ACR_LOGIN_SERVER'..."
+info "Step 3: Granting kubelet identity AcrPull on ACR '$ACR_LOGIN_SERVER'..."
 
 KUBELET_CLIENT_ID=$(az aks show \
     --name "$AKS_CLUSTER" \
@@ -149,9 +164,9 @@ else
 fi
 
 ###############################################################################
-# Step 3 — Get credentials
+# Step 4 — Get credentials
 ###############################################################################
-info "Step 3: Fetching kubeconfig for cluster '$AKS_CLUSTER'..."
+info "Step 4: Fetching kubeconfig for cluster '$AKS_CLUSTER'..."
 run az aks get-credentials \
     --name "$AKS_CLUSTER" \
     --resource-group "$AKS_RG" \
@@ -160,9 +175,9 @@ run az aks get-credentials \
 info "Current kubectl context: $(kubectl config current-context)"
 
 ###############################################################################
-# Step 4 — Install OPA Gatekeeper
+# Step 5 — Install OPA Gatekeeper
 ###############################################################################
-info "Step 4: Installing OPA Gatekeeper..."
+info "Step 5: Installing OPA Gatekeeper..."
 
 helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts --force-update
 helm repo update
@@ -181,9 +196,9 @@ else
 fi
 
 ###############################################################################
-# Step 5 — Install Ratify
+# Step 6 — Install Ratify
 ###############################################################################
-info "Step 5: Installing Ratify..."
+info "Step 6: Installing Ratify..."
 
 helm repo add ratify https://notaryproject.github.io/ratify --force-update
 helm repo update
@@ -201,9 +216,9 @@ else
 fi
 
 ###############################################################################
-# Step 6 — Download root certificates and configure Ratify
+# Step 7 — Download root certificates and configure Ratify
 ###############################################################################
-info "Step 6: Configuring Ratify with Artifact Signing trust store..."
+info "Step 7: Configuring Ratify with Artifact Signing trust store..."
 
 SIGNING_CERT_FILE="msft-root-certificate-authority-2020.crt"
 TSA_CERT_FILE="msft-tsa-root-certificate-authority-2020.crt"
@@ -276,9 +291,9 @@ EOF
 info "Ratify CertificateStore and Verifier configured."
 
 ###############################################################################
-# Step 7 — Apply Gatekeeper ConstraintTemplate and constraint
+# Step 8 — Apply Gatekeeper ConstraintTemplate and constraint
 ###############################################################################
-info "Step 7: Applying Gatekeeper ConstraintTemplate and RatifyVerification constraint..."
+info "Step 8: Applying Gatekeeper ConstraintTemplate and RatifyVerification constraint..."
 
 kubectl apply -f - <<'EOF'
 apiVersion: templates.gatekeeper.sh/v1

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -224,11 +224,16 @@ if kubectl get verifier verifier-notation -n gatekeeper-system &>/dev/null; then
 fi
 
 # The Helm chart registers a ratify-mutation-provider ExternalData Provider CR
-# even when mutationProvider.enable=false (server not running). Delete it to
-# prevent Gatekeeper's mutation webhook from trying to reach a dead endpoint.
+# and an AssignMetadata CR even when mutationProvider.enable=false (server not
+# running). Delete both to prevent Gatekeeper's mutation webhook from trying to
+# reach a dead endpoint or resolve missing provider references.
 if kubectl get provider ratify-mutation-provider -n gatekeeper-system &>/dev/null; then
     info "Removing ratify-mutation-provider ExternalData Provider CR (mutation not used)..."
     kubectl delete provider ratify-mutation-provider -n gatekeeper-system
+fi
+if kubectl get assignmetadata -n gatekeeper-system 2>/dev/null | grep -q ratify; then
+    info "Removing Ratify AssignMetadata CR (mutation not used)..."
+    kubectl delete assignmetadata -n gatekeeper-system -l app.kubernetes.io/name=ratify --ignore-not-found
 fi
 
 ###############################################################################

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -244,7 +244,7 @@ spec:
   name: oras
   parameters:
     authProvider:
-      name: azureWorkloadIdentity
+      name: azureManagedIdentity
       clientID: "${KUBELET_CLIENT_ID}"
 EOF
 

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -275,14 +275,13 @@ helm repo add ratify https://notaryproject.github.io/ratify --force-update
 helm repo update
 
 if helm status ratify --namespace gatekeeper-system &>/dev/null; then
-    info "Ratify already installed — skipping Helm install."
-    info "Ensuring workload identity client ID is set on the Ratify service account..."
-    RATIFY_SA=$(kubectl get pod -n gatekeeper-system -l app.kubernetes.io/name=ratify \
-        -o jsonpath='{.items[0].spec.serviceAccountName}' 2>/dev/null || echo "ratify")
-    kubectl annotate serviceaccount "$RATIFY_SA" \
-        -n gatekeeper-system \
-        azure.workload.identity/client-id="$RATIFY_MI_CLIENT_ID" \
-        --overwrite
+    info "Ratify already installed — upgrading to apply workload identity client ID..."
+    run helm upgrade ratify ratify/ratify \
+        --namespace gatekeeper-system \
+        --reuse-values \
+        --set azureWorkloadIdentity.clientId="$RATIFY_MI_CLIENT_ID" \
+        --wait
+    info "Ratify upgraded."
 else
     run helm install ratify ratify/ratify \
         --namespace gatekeeper-system \
@@ -293,6 +292,18 @@ else
         --wait
     info "Ratify installed."
 fi
+
+# Annotate the Ratify SA so the Azure Workload Identity webhook injects
+# AZURE_CLIENT_ID into the pod env. The helm chart may not do this reliably
+# on upgrades; do it explicitly using the actual SA name from the running pod.
+RATIFY_SA=$(kubectl get serviceaccount -n gatekeeper-system \
+    -l app.kubernetes.io/name=ratify \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "ratify-admin")
+info "Annotating Ratify service account '$RATIFY_SA' with workload identity client ID..."
+kubectl annotate serviceaccount "$RATIFY_SA" \
+    -n gatekeeper-system \
+    azure.workload.identity/client-id="$RATIFY_MI_CLIENT_ID" \
+    --overwrite
 
 # Always clean up mutation CRs — the Helm chart creates them regardless of the
 # mutationProvider.enable flag, and helm upgrade recreates them. Purge them

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -226,7 +226,22 @@ fi
 ###############################################################################
 # Step 7 — Download root certificates and configure Ratify
 ###############################################################################
-info "Step 7: Configuring Ratify with Artifact Signing trust store..."
+info "Step 7: Configuring Ratify with ORAS store, Artifact Signing trust store, and Notation Verifier..."
+
+info "Configuring Ratify ORAS store with workload identity auth..."
+kubectl apply -f - <<EOF
+apiVersion: config.ratify.deislabs.io/v1beta1
+kind: Store
+metadata:
+  name: store-oras
+  namespace: gatekeeper-system
+spec:
+  name: oras
+  parameters:
+    authProvider:
+      name: azureWorkloadIdentity
+      clientID: "${KUBELET_CLIENT_ID}"
+EOF
 
 SIGNING_CERT_FILE="msft-root-certificate-authority-2020.crt"
 TSA_CERT_FILE="msft-tsa-root-certificate-authority-2020.crt"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -215,23 +215,32 @@ OIDC_ISSUER=$(az aks show \
 info "OIDC issuer: $OIDC_ISSUER"
 
 # The Ratify Helm chart creates the service account "ratify" in gatekeeper-system.
-# The federated credential links the AKS OIDC issuer + that service account to
-# the managed identity, so Ratify pods can obtain Azure tokens automatically.
+# The federated credential links the AKS OIDC issuer + the Ratify service
+# account to the managed identity, so Ratify pods can obtain Azure tokens.
+# Note: the Ratify Helm chart creates the SA as "ratify-admin", not "ratify".
 FEDERATED_CRED_NAME="ratify-federated-cred"
+RATIFY_SA_NAME="ratify-admin"
 if az identity federated-credential show \
     --name "$FEDERATED_CRED_NAME" \
     --identity-name "$RATIFY_MI_NAME" \
     --resource-group "$AKS_RG" &>/dev/null; then
-    info "Federated credential '$FEDERATED_CRED_NAME' already exists — skipping."
+    info "Federated credential '$FEDERATED_CRED_NAME' already exists — updating subject to ensure correct SA name..."
+    run az identity federated-credential update \
+        --name "$FEDERATED_CRED_NAME" \
+        --identity-name "$RATIFY_MI_NAME" \
+        --resource-group "$AKS_RG" \
+        --issuer "$OIDC_ISSUER" \
+        --subject "system:serviceaccount:gatekeeper-system:${RATIFY_SA_NAME}" \
+        --audience "api://AzureADTokenExchange"
 else
     run az identity federated-credential create \
         --name "$FEDERATED_CRED_NAME" \
         --identity-name "$RATIFY_MI_NAME" \
         --resource-group "$AKS_RG" \
         --issuer "$OIDC_ISSUER" \
-        --subject "system:serviceaccount:gatekeeper-system:ratify" \
+        --subject "system:serviceaccount:gatekeeper-system:${RATIFY_SA_NAME}" \
         --audience "api://AzureADTokenExchange"
-    info "Federated credential created for Ratify service account."
+    info "Federated credential created for Ratify service account '$RATIFY_SA_NAME'."
 fi
 
 ###############################################################################

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -275,7 +275,12 @@ helm repo add ratify https://notaryproject.github.io/ratify --force-update
 helm repo update
 
 if helm status ratify --namespace gatekeeper-system &>/dev/null; then
-    info "Ratify already installed — skipping."
+    info "Ratify already installed — skipping Helm install."
+    info "Ensuring workload identity client ID is set on the Ratify service account..."
+    kubectl annotate serviceaccount ratify \
+        -n gatekeeper-system \
+        azure.workload.identity/client-id="$RATIFY_MI_CLIENT_ID" \
+        --overwrite
 else
     run helm install ratify ratify/ratify \
         --namespace gatekeeper-system \
@@ -287,32 +292,27 @@ else
     info "Ratify installed."
 fi
 
-# The Helm chart creates a default verifier-notation CR with the legacy
-# verificationCerts path set. Remove it so our Step 7 CR (which uses only
-# the new verificationCertStores format) does not conflict with it.
-if kubectl get verifier verifier-notation -n gatekeeper-system &>/dev/null; then
-    info "Removing default Ratify verifier-notation CR (will be replaced in Step 7)..."
-    kubectl delete verifier verifier-notation -n gatekeeper-system
-fi
-
-# The Helm chart registers mutation CRs even when mutationProvider.enable=false
-# (server not running). Delete them all to prevent Gatekeeper's mutation webhook
-# from trying to reach a dead endpoint or resolve missing provider references.
-# This includes: ExternalData Provider, AssignMetadata, and Assign CRs.
-if kubectl get provider ratify-mutation-provider -n gatekeeper-system &>/dev/null; then
-    info "Removing ratify-mutation-provider ExternalData Provider CR (mutation not used)..."
-    kubectl delete provider ratify-mutation-provider -n gatekeeper-system
-fi
-if kubectl get assignmetadata -n gatekeeper-system 2>/dev/null | grep -q ratify; then
-    info "Removing Ratify AssignMetadata CRs (mutation not used)..."
-    kubectl delete assignmetadata -n gatekeeper-system -l app.kubernetes.io/name=ratify --ignore-not-found
-fi
-info "Removing Ratify Assign mutation CRs (mutation not used)..."
+# Always clean up mutation CRs — the Helm chart creates them regardless of the
+# mutationProvider.enable flag, and helm upgrade recreates them. Purge them
+# every run so the Gatekeeper mutation webhook never references a Ratify
+# provider that isn't running.
+info "Removing Ratify mutation CRs (mutation not used in this demo)..."
+kubectl delete provider ratify-mutation-provider \
+    -n gatekeeper-system --ignore-not-found
+kubectl delete assignmetadata \
+    -n gatekeeper-system -l app.kubernetes.io/name=ratify --ignore-not-found
 kubectl delete assign \
     mutate-cronjob-image mutate-cronjob-image-ephemeral mutate-cronjob-image-init \
     mutate-pod-image mutate-pod-image-ephemeral mutate-pod-image-init \
     mutate-workload-image mutate-workload-image-ephemeral mutate-workload-image-init \
     --ignore-not-found
+
+# Remove the default verifier-notation CR created by the Helm chart — it uses
+# the legacy verificationCerts path; our Step 7 CR uses verificationCertStores.
+if kubectl get verifier verifier-notation -n gatekeeper-system &>/dev/null; then
+    info "Removing default Ratify verifier-notation CR (will be replaced in Step 7)..."
+    kubectl delete verifier verifier-notation -n gatekeeper-system
+fi
 
 ###############################################################################
 # Step 7 — Download root certificates and configure Ratify

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -210,6 +210,7 @@ else
         --namespace gatekeeper-system \
         --set featureFlags.RATIFY_CERT_ROTATION=true \
         --set akvCertConfig.enabled=false \
+        --set mutationProvider.enable=false \
         --wait
     info "Ratify installed."
 fi

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -371,17 +371,22 @@ EOF
 
 SIGNING_CERT_FILE="msft-root-certificate-authority-2020.crt"
 TSA_CERT_FILE="msft-tsa-root-certificate-authority-2020.crt"
+SIGNING_CERT_PEM_FILE="msft-root-certificate-authority-2020.pem"
+TSA_CERT_PEM_FILE="msft-tsa-root-certificate-authority-2020.pem"
 
 info "Downloading Artifact Signing root CA..."
 run curl -sLo "$SIGNING_CERT_FILE" "$TS_SIGNING_ROOT_CERT"
-run openssl x509 -inform DER -in "$SIGNING_CERT_FILE" -out "$SIGNING_CERT_FILE"
+# Use a separate output file to avoid macOS/LibreSSL in-place truncation bug
+# where the -out file is truncated before -in is read when both paths are equal.
+run openssl x509 -inform DER -in "$SIGNING_CERT_FILE" -out "$SIGNING_CERT_PEM_FILE"
+SIGNING_CERT_PEM=$(cat "$SIGNING_CERT_PEM_FILE")
+[[ -z "$SIGNING_CERT_PEM" ]] && { error "Signing root CA PEM is empty — cert download/conversion failed."; exit 1; }
 
 info "Downloading Artifact Signing TSA root CA..."
 run curl -sLo "$TSA_CERT_FILE" "$TS_TSA_ROOT_CERT"
-run openssl x509 -inform DER -in "$TSA_CERT_FILE" -out "$TSA_CERT_FILE"
-
-SIGNING_CERT_PEM=$(cat "$SIGNING_CERT_FILE")
-TSA_CERT_PEM=$(cat "$TSA_CERT_FILE")
+run openssl x509 -inform DER -in "$TSA_CERT_FILE" -out "$TSA_CERT_PEM_FILE"
+TSA_CERT_PEM=$(cat "$TSA_CERT_PEM_FILE")
+[[ -z "$TSA_CERT_PEM" ]] && { error "TSA root CA PEM is empty — cert download/conversion failed."; exit 1; }
 
 kubectl apply -f - <<EOF
 apiVersion: config.ratify.deislabs.io/v1beta1
@@ -563,7 +568,26 @@ echo "  Gatekeeper:    $(helm status gatekeeper -n gatekeeper-system --short 2>/
 echo "  Ratify:        $(helm status ratify -n gatekeeper-system --short 2>/dev/null || echo 'installed')"
 echo
 echo "Next steps:"
-echo "  1. Sign your image:   notation sign ... <image>"
-echo "  2. Test admission:    kubectl run signed --image=<signed-image>"
-echo "  3. Test rejection:    kubectl run unsigned --image=nginx:latest"
+echo "  1. Log in to Azure and ACR:"
+echo "       az login --tenant <tenant-id>"
+echo "       az acr login --name $ACR_NAME"
+echo ""
+echo "  2. Sign the image (TSA cert downloaded by this script):"
+echo "       notation sign --signature-format cose \\"
+echo "           --timestamp-url '$TS_TSA_URL' \\"
+echo "           --timestamp-root-cert '$TSA_CERT_PEM_FILE' \\"
+echo "           --id '$TS_CERT_PROFILE' \\"
+echo "           --plugin azure-artifactsigning \\"
+echo "           --plugin-config accountName='$TS_ACCOUNT_NAME' \\"
+echo "           --plugin-config baseUrl='$TS_ACCT_URL' \\"
+echo "           --plugin-config certProfile='$TS_CERT_PROFILE' \\"
+echo "           ${ACR_LOGIN_SERVER}/nginx:1.29-alpine-signed"
+echo ""
+echo "  3. Verify the signature is present:"
+echo "       notation ls ${ACR_LOGIN_SERVER}/nginx:1.29-alpine-signed"
+echo ""
+echo "  4. Test admission (signed image should run):"
+echo "       kubectl apply -f nginx-signed-demo.yaml"
+echo "  5. Test rejection (unsigned image should be blocked):"
+echo "       kubectl apply -f nginx-unsigned-demo.yaml"
 echo

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -215,6 +215,14 @@ else
     info "Ratify installed."
 fi
 
+# The Helm chart creates a default verifier-notation CR with the legacy
+# verificationCerts path set. Remove it so our Step 7 CR (which uses only
+# the new verificationCertStores format) does not conflict with it.
+if kubectl get verifier verifier-notation -n gatekeeper-system &>/dev/null; then
+    info "Removing default Ratify verifier-notation CR (will be replaced in Step 7)..."
+    kubectl delete verifier verifier-notation -n gatekeeper-system
+fi
+
 ###############################################################################
 # Step 7 — Download root certificates and configure Ratify
 ###############################################################################

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -79,27 +79,9 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Log out and log back in to ensure the correct subscription
+# Step 1 — Create the AKS cluster
 ###############################################################################
-info "Step 1: Logging out of Azure CLI to ensure a clean session..."
-az logout --verbose 2>/dev/null || true
-info "Logging in to Azure CLI..."
-az login
-if ! az account show --query id -o tsv &>/dev/null; then
-    error "No active Azure CLI session. Authenticate first with one of:"
-    error "  az login                                  (interactive)"
-    error "  az login --service-principal ...          (service principal)"
-    error "  az login --identity                       (managed identity)"
-    exit 1
-fi
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-SUBSCRIPTION=$(az account show --query name -o tsv)
-info "Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
-
-###############################################################################
-# Step 2 — Create the AKS cluster
-###############################################################################
-info "Step 2: Creating AKS cluster '$AKS_CLUSTER' in resource group '$AKS_RG'..."
+info "Step 1: Creating AKS cluster '$AKS_CLUSTER' in resource group '$AKS_RG'..."
 
 if az aks show --name "$AKS_CLUSTER" --resource-group "$AKS_RG" &>/dev/null; then
     info "Cluster '$AKS_CLUSTER' already exists — skipping creation."
@@ -137,9 +119,9 @@ if [[ "$_az_policy" == "true" ]]; then
 fi
 
 ###############################################################################
-# Step 3 — Grant kubelet identity AcrPull on the ACR
+# Step 2 — Grant kubelet identity AcrPull on the ACR
 ###############################################################################
-info "Step 3: Granting kubelet identity AcrPull on ACR '$ACR_LOGIN_SERVER'..."
+info "Step 2: Granting kubelet identity AcrPull on ACR '$ACR_LOGIN_SERVER'..."
 
 KUBELET_CLIENT_ID=$(az aks show \
     --name "$AKS_CLUSTER" \
@@ -167,9 +149,9 @@ else
 fi
 
 ###############################################################################
-# Step 4 — Get credentials
+# Step 3 — Get credentials
 ###############################################################################
-info "Step 4: Fetching kubeconfig for cluster '$AKS_CLUSTER'..."
+info "Step 3: Fetching kubeconfig for cluster '$AKS_CLUSTER'..."
 run az aks get-credentials \
     --name "$AKS_CLUSTER" \
     --resource-group "$AKS_RG" \
@@ -178,9 +160,9 @@ run az aks get-credentials \
 info "Current kubectl context: $(kubectl config current-context)"
 
 ###############################################################################
-# Step 5 — Install OPA Gatekeeper
+# Step 4 — Install OPA Gatekeeper
 ###############################################################################
-info "Step 5: Installing OPA Gatekeeper..."
+info "Step 4: Installing OPA Gatekeeper..."
 
 helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts --force-update
 helm repo update
@@ -199,9 +181,9 @@ else
 fi
 
 ###############################################################################
-# Step 6 — Install Ratify
+# Step 5 — Install Ratify
 ###############################################################################
-info "Step 6: Installing Ratify..."
+info "Step 5: Installing Ratify..."
 
 helm repo add ratify https://notaryproject.github.io/ratify --force-update
 helm repo update
@@ -219,9 +201,9 @@ else
 fi
 
 ###############################################################################
-# Step 7 — Download root certificates and configure Ratify
+# Step 6 — Download root certificates and configure Ratify
 ###############################################################################
-info "Step 7: Configuring Ratify with Artifact Signing trust store..."
+info "Step 6: Configuring Ratify with Artifact Signing trust store..."
 
 SIGNING_CERT_FILE="msft-root-certificate-authority-2020.crt"
 TSA_CERT_FILE="msft-tsa-root-certificate-authority-2020.crt"
@@ -294,9 +276,9 @@ EOF
 info "Ratify CertificateStore and Verifier configured."
 
 ###############################################################################
-# Step 8 — Apply Gatekeeper ConstraintTemplate and constraint
+# Step 7 — Apply Gatekeeper ConstraintTemplate and constraint
 ###############################################################################
-info "Step 8: Applying Gatekeeper ConstraintTemplate and RatifyVerification constraint..."
+info "Step 7: Applying Gatekeeper ConstraintTemplate and RatifyVerification constraint..."
 
 kubectl apply -f - <<'EOF'
 apiVersion: templates.gatekeeper.sh/v1

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -379,7 +379,27 @@ spec:
   parameters:
     value: |
 $(echo "$TSA_CERT_PEM" | sed 's/^/      /')
----
+EOF
+
+info "Waiting for CertificateStore CRs to be reconciled..."
+# CertificateStore CRs have no standard readiness condition; poll the
+# isSuccess field in the status block that Ratify sets after reconciliation.
+for _cr in artifact-signing-root artifact-signing-tsa-root; do
+    for _i in $(seq 1 30); do
+        _ok=$(kubectl get certificatestore "$_cr" \
+            -n gatekeeper-system \
+            -o jsonpath='{.status.error}' 2>/dev/null || echo "not-found")
+        # An empty status.error means the controller reconciled successfully
+        if [[ "$_ok" == "" ]]; then
+            info "  CertificateStore '$_cr' reconciled successfully."
+            break
+        fi
+        [[ $_i -eq 30 ]] && { error "Timed out waiting for CertificateStore '$_cr'"; exit 1; }
+        sleep 4
+    done
+done
+
+kubectl apply -f - <<EOF
 apiVersion: config.ratify.deislabs.io/v1beta1
 kind: Verifier
 metadata:

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -6,11 +6,12 @@
 # What this script does:
 #   1. Verify Azure login
 #   2. Create AKS cluster (OIDC + workload identity enabled)
-#   3. Grant kubelet identity AcrPull on the ACR
+#   3. Grant kubelet identity AcrPull on the ACR (for node image pulls)
+#   3b. Create Ratify User-Assigned Managed Identity with workload identity federation
 #   4. Get credentials (kubectl)
 #   5. Install OPA Gatekeeper via Helm
-#   6. Install Ratify via Helm
-#   7. Configure Ratify: CertificateStore (CA + TSA) and Notation Verifier
+#   6. Install Ratify via Helm (with workload identity client ID)
+#   7. Configure Ratify: store-oras (azureWorkloadIdentity), CertificateStore (CA + TSA), Notation Verifier
 #   8. Apply Gatekeeper ConstraintTemplate + RatifyVerification constraint
 #
 # Usage:
@@ -164,6 +165,76 @@ else
 fi
 
 ###############################################################################
+# Step 3b — Create Ratify Managed Identity and configure Workload Identity
+###############################################################################
+info "Step 3b: Setting up Ratify workload identity..."
+
+if az identity show --name "$RATIFY_MI_NAME" --resource-group "$AKS_RG" &>/dev/null; then
+    info "Managed identity '$RATIFY_MI_NAME' already exists — skipping creation."
+else
+    run az identity create \
+        --name "$RATIFY_MI_NAME" \
+        --resource-group "$AKS_RG" \
+        --location "$AKS_LOCATION"
+    info "Managed identity '$RATIFY_MI_NAME' created."
+fi
+
+RATIFY_MI_CLIENT_ID=$(az identity show \
+    --name "$RATIFY_MI_NAME" \
+    --resource-group "$AKS_RG" \
+    --query clientId -o tsv)
+
+RATIFY_MI_PRINCIPAL_ID=$(az identity show \
+    --name "$RATIFY_MI_NAME" \
+    --resource-group "$AKS_RG" \
+    --query principalId -o tsv)
+
+info "Granting AcrPull to Ratify managed identity on '$ACR_LOGIN_SERVER'..."
+EXISTING_RATIFY_ASSIGNMENT=$(az role assignment list \
+    --assignee "$RATIFY_MI_PRINCIPAL_ID" \
+    --role AcrPull \
+    --scope "$ACR_ID" \
+    --query "[0].id" -o tsv 2>/dev/null || true)
+
+if [[ -n "$EXISTING_RATIFY_ASSIGNMENT" ]]; then
+    info "AcrPull role already assigned to Ratify MI — skipping."
+else
+    run az role assignment create \
+        --role AcrPull \
+        --assignee-object-id "$RATIFY_MI_PRINCIPAL_ID" \
+        --assignee-principal-type ServicePrincipal \
+        --scope "$ACR_ID"
+    info "AcrPull role assigned to Ratify managed identity."
+fi
+
+info "Getting AKS OIDC issuer URL..."
+OIDC_ISSUER=$(az aks show \
+    --name "$AKS_CLUSTER" \
+    --resource-group "$AKS_RG" \
+    --query "oidcIssuerProfile.issuerUrl" -o tsv)
+info "OIDC issuer: $OIDC_ISSUER"
+
+# The Ratify Helm chart creates the service account "ratify" in gatekeeper-system.
+# The federated credential links the AKS OIDC issuer + that service account to
+# the managed identity, so Ratify pods can obtain Azure tokens automatically.
+FEDERATED_CRED_NAME="ratify-federated-cred"
+if az identity federated-credential show \
+    --name "$FEDERATED_CRED_NAME" \
+    --identity-name "$RATIFY_MI_NAME" \
+    --resource-group "$AKS_RG" &>/dev/null; then
+    info "Federated credential '$FEDERATED_CRED_NAME' already exists — skipping."
+else
+    run az identity federated-credential create \
+        --name "$FEDERATED_CRED_NAME" \
+        --identity-name "$RATIFY_MI_NAME" \
+        --resource-group "$AKS_RG" \
+        --issuer "$OIDC_ISSUER" \
+        --subject "system:serviceaccount:gatekeeper-system:ratify" \
+        --audience "api://AzureADTokenExchange"
+    info "Federated credential created for Ratify service account."
+fi
+
+###############################################################################
 # Step 4 — Get credentials
 ###############################################################################
 info "Step 4: Fetching kubeconfig for cluster '$AKS_CLUSTER'..."
@@ -211,6 +282,7 @@ else
         --set featureFlags.RATIFY_CERT_ROTATION=true \
         --set akvCertConfig.enabled=false \
         --set mutationProvider.enable=false \
+        --set azureWorkloadIdentity.clientId="$RATIFY_MI_CLIENT_ID" \
         --wait
     info "Ratify installed."
 fi
@@ -247,22 +319,11 @@ kubectl delete assign \
 ###############################################################################
 info "Step 7: Configuring Ratify with ORAS store, Artifact Signing trust store, and Notation Verifier..."
 
-info "Configuring Ratify ORAS store with k8Secrets auth..."
-# Ratify v1.4.0 has a bug in the azureManagedIdentity auth provider: the
-# registryHostGetter field is never initialized in the factory, causing a nil
-# pointer panic on every verification call. Use k8Secrets instead.
-#
-# Obtain a short-lived ACR access token from the current Azure CLI session and
-# store it as a Kubernetes Docker registry secret in gatekeeper-system. Ratify
-# uses this secret to authenticate to ACR when pulling referrer artifacts.
-info "Creating ACR pull secret for Ratify..."
-ACR_TOKEN=$(az acr login --name "${ACR_NAME}" --expose-token --output tsv --query accessToken)
-kubectl create secret docker-registry ratify-acr-secret \
-    --namespace gatekeeper-system \
-    --docker-server="${ACR_REGISTRY}" \
-    --docker-username="00000000-0000-0000-0000-000000000000" \
-    --docker-password="${ACR_TOKEN}" \
-    --dry-run=client -o yaml | kubectl apply -f -
+info "Configuring Ratify ORAS store with workload identity auth..."
+# The azureWorkloadIdentity auth provider uses the federated credential created
+# in Step 3b to exchange the Ratify pod's service account token for an Azure
+# access token, which is then used to authenticate to ACR. No secrets or
+# short-lived ACR tokens need to be managed manually.
 
 # The Helm chart creates a default store-oras CR without the last-applied-configuration
 # annotation; delete it first so kubectl apply creates a clean resource.
@@ -279,10 +340,7 @@ spec:
   name: oras
   parameters:
     authProvider:
-      name: k8Secrets
-      secrets:
-        - registryUri: "${ACR_REGISTRY}"
-          secretName: ratify-acr-secret
+      name: azureWorkloadIdentity
 EOF
 
 SIGNING_CERT_FILE="msft-root-certificate-authority-2020.crt"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -247,7 +247,23 @@ kubectl delete assign \
 ###############################################################################
 info "Step 7: Configuring Ratify with ORAS store, Artifact Signing trust store, and Notation Verifier..."
 
-info "Configuring Ratify ORAS store with workload identity auth..."
+info "Configuring Ratify ORAS store with k8Secrets auth..."
+# Ratify v1.4.0 has a bug in the azureManagedIdentity auth provider: the
+# registryHostGetter field is never initialized in the factory, causing a nil
+# pointer panic on every verification call. Use k8Secrets instead.
+#
+# Obtain a short-lived ACR access token from the current Azure CLI session and
+# store it as a Kubernetes Docker registry secret in gatekeeper-system. Ratify
+# uses this secret to authenticate to ACR when pulling referrer artifacts.
+info "Creating ACR pull secret for Ratify..."
+ACR_TOKEN=$(az acr login --name "${ACR_NAME}" --expose-token --output tsv --query accessToken)
+kubectl create secret docker-registry ratify-acr-secret \
+    --namespace gatekeeper-system \
+    --docker-server="${ACR_REGISTRY}" \
+    --docker-username="00000000-0000-0000-0000-000000000000" \
+    --docker-password="${ACR_TOKEN}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
 # The Helm chart creates a default store-oras CR without the last-applied-configuration
 # annotation; delete it first so kubectl apply creates a clean resource.
 if kubectl get store store-oras -n gatekeeper-system &>/dev/null; then
@@ -263,8 +279,10 @@ spec:
   name: oras
   parameters:
     authProvider:
-      name: azureManagedIdentity
-      clientID: "${KUBELET_CLIENT_ID}"
+      name: k8Secrets
+      secrets:
+        - registryUri: "${ACR_REGISTRY}"
+          secretName: ratify-acr-secret
 EOF
 
 SIGNING_CERT_FILE="msft-root-certificate-authority-2020.crt"
@@ -358,7 +376,7 @@ spec:
         package ratifyverification
         violation[{"msg": msg}] {
           subject := input.review.object.spec.containers[_].image
-          response := external_data({"provider": "ratify", "keys": [subject]})
+          response := external_data({"provider": "ratify-provider", "keys": [subject]})
           result := response.responses[_]
           result[0] == subject
           result[1].isSuccess == false

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -229,6 +229,11 @@ fi
 info "Step 7: Configuring Ratify with ORAS store, Artifact Signing trust store, and Notation Verifier..."
 
 info "Configuring Ratify ORAS store with workload identity auth..."
+# The Helm chart creates a default store-oras CR without the last-applied-configuration
+# annotation; delete it first so kubectl apply creates a clean resource.
+if kubectl get store store-oras -n gatekeeper-system &>/dev/null; then
+    kubectl delete store store-oras -n gatekeeper-system
+fi
 kubectl apply -f - <<EOF
 apiVersion: config.ratify.deislabs.io/v1beta1
 kind: Store

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -57,15 +57,11 @@ run() {
 }
 
 ###############################################################################
-# Default values — override by exporting before running
+# Load shared defaults (override by exporting before running)
 ###############################################################################
-: "${AKS_CLUSTER:=aks-tsm-signing-demo}"
-: "${AKS_RG:=rg-tsm-signing}"
-: "${AKS_LOCATION:=westus2}"
-: "${ACR_LOGIN_SERVER:=acrtsmpremiumsku.azurecr.io}"
-: "${TS_CERT_SUBJECT:=CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=Cloud Native Security and Registries, L=Redmond, S=Washington, C=US}"
-: "${TS_SIGNING_ROOT_CERT:=https://www.microsoft.com/pkiops/certs/Microsoft%20Enterprise%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt}"
-: "${TS_TSA_ROOT_CERT:=http://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=defaults.sh
+source "${SCRIPT_DIR}/defaults.sh"
 
 ###############################################################################
 # Validate required variables

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -223,6 +223,14 @@ if kubectl get verifier verifier-notation -n gatekeeper-system &>/dev/null; then
     kubectl delete verifier verifier-notation -n gatekeeper-system
 fi
 
+# The Helm chart registers a ratify-mutation-provider ExternalData Provider CR
+# even when mutationProvider.enable=false (server not running). Delete it to
+# prevent Gatekeeper's mutation webhook from trying to reach a dead endpoint.
+if kubectl get provider ratify-mutation-provider -n gatekeeper-system &>/dev/null; then
+    info "Removing ratify-mutation-provider ExternalData Provider CR (mutation not used)..."
+    kubectl delete provider ratify-mutation-provider -n gatekeeper-system
+fi
+
 ###############################################################################
 # Step 7 — Download root certificates and configure Ratify
 ###############################################################################

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -278,7 +278,7 @@ spec:
       trustPolicies:
         - name: default
           registryScopes:
-            - "*"
+            - "${ACR_LOGIN_SERVER}/nginx"
           signatureVerification:
             level: strict
           trustStores:

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -261,7 +261,7 @@ else
         --create-namespace \
         --set enableExternalData=true \
         --set validatingWebhookTimeoutSeconds=5 \
-        --set mutatingWebhookTimeoutSeconds=2 \
+        --set enableMutation=false \
         --wait
     info "Gatekeeper installed."
 fi
@@ -277,7 +277,9 @@ helm repo update
 if helm status ratify --namespace gatekeeper-system &>/dev/null; then
     info "Ratify already installed — skipping Helm install."
     info "Ensuring workload identity client ID is set on the Ratify service account..."
-    kubectl annotate serviceaccount ratify \
+    RATIFY_SA=$(kubectl get pod -n gatekeeper-system -l app.kubernetes.io/name=ratify \
+        -o jsonpath='{.items[0].spec.serviceAccountName}' 2>/dev/null || echo "ratify")
+    kubectl annotate serviceaccount "$RATIFY_SA" \
         -n gatekeeper-system \
         azure.workload.identity/client-id="$RATIFY_MI_CLIENT_ID" \
         --overwrite
@@ -305,6 +307,10 @@ kubectl delete assign \
     mutate-cronjob-image mutate-cronjob-image-ephemeral mutate-cronjob-image-init \
     mutate-pod-image mutate-pod-image-ephemeral mutate-pod-image-init \
     mutate-workload-image mutate-workload-image-ephemeral mutate-workload-image-init \
+    --ignore-not-found
+# Also remove the Gatekeeper mutation webhook itself so no mutation provider is
+# ever called, regardless of what Helm or other tooling reconstitutes.
+kubectl delete mutatingwebhookconfiguration gatekeeper-mutating-webhook-configuration \
     --ignore-not-found
 
 # Remove the default verifier-notation CR created by the Helm chart — it uses

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -79,9 +79,12 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Verify Azure login
+# Step 1 — Log out and log back in to ensure the correct subscription
 ###############################################################################
-info "Step 1: Verifying Azure login..."
+info "Step 1: Logging out of Azure CLI to ensure a clean session..."
+az logout --verbose 2>/dev/null || true
+info "Logging in to Azure CLI..."
+az login
 if ! az account show --query id -o tsv &>/dev/null; then
     error "No active Azure CLI session. Authenticate first with one of:"
     error "  az login                                  (interactive)"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -83,11 +83,15 @@ done
 ###############################################################################
 info "Step 1: Verifying Azure login..."
 if ! az account show --query id -o tsv &>/dev/null; then
-    warn "Not logged in. Running az login..."
-    run az login
+    error "No active Azure CLI session. Authenticate first with one of:"
+    error "  az login                                  (interactive)"
+    error "  az login --service-principal ...          (service principal)"
+    error "  az login --identity                       (managed identity)"
+    exit 1
 fi
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SUBSCRIPTION=$(az account show --query name -o tsv)
-info "Using subscription: $SUBSCRIPTION"
+info "Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
 
 ###############################################################################
 # Step 2 — Create the AKS cluster

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -22,7 +22,7 @@
 #   AKS_CLUSTER        - Name of the AKS cluster to create
 #   AKS_RG             - Resource group for the AKS cluster
 #   AKS_LOCATION       - Azure region for the AKS cluster (e.g. westus2)
-#   ACR_LOGIN_SERVER   - ACR login server (e.g. acrtsmpremiumsku.azurecr.io)
+#   ACR_LOGIN_SERVER   - ACR login server (e.g. acrtsmkubeconeu2026demo.azurecr.io)
 #   TS_CERT_SUBJECT    - Expected certificate subject for Notation trust policy
 #                        e.g. "CN=..., O=..., OU=..., L=..., S=..., C=US"
 #   TS_SIGNING_ROOT_CERT - URL of the Artifact Signing root CA certificate

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-aks.sh
@@ -432,13 +432,45 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package ratifyverification
+
+        # Collect images from all container types (fail-closed: any unverified image blocks)
+        _images[img] {
+          img := input.review.object.spec.containers[_].image
+        }
+        _images[img] {
+          img := input.review.object.spec.initContainers[_].image
+        }
+        _images[img] {
+          img := input.review.object.spec.ephemeralContainers[_].image
+        }
+
+        # Case 1: Ratify explicitly reports verification failure
         violation[{"msg": msg}] {
-          subject := input.review.object.spec.containers[_].image
-          response := external_data({"provider": "ratify-provider", "keys": [subject]})
+          img := _images[_]
+          response := external_data({"provider": "ratify-provider", "keys": [img]})
           result := response.responses[_]
-          result[0] == subject
+          result[0] == img
           result[1].isSuccess == false
-          msg := sprintf("Signature verification failed for image %v: %v", [subject, result[1].verifierReports])
+          msg := sprintf("Signature verification failed for image %v: %v", [img, result[1].verifierReports])
+        }
+
+        # Case 2: Ratify returned an error for the image (e.g., can't pull referrers,
+        # registry auth failure). Treat as a denial to keep the policy fail-closed.
+        violation[{"msg": msg}] {
+          img := _images[_]
+          response := external_data({"provider": "ratify-provider", "keys": [img]})
+          err := response.errors[_]
+          err[0] == img
+          msg := sprintf("Ratify error verifying image %v: %v", [img, err[1]])
+        }
+
+        # Case 3: The ExternalData call itself failed (Gatekeeper can't reach Ratify).
+        # Deny to keep the policy fail-closed.
+        violation[{"msg": msg}] {
+          img := _images[_]
+          response := external_data({"provider": "ratify-provider", "keys": [img]})
+          response.system_error != ""
+          msg := sprintf("Ratify system error for image %v: %v", [img, response.system_error])
         }
 EOF
 

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -79,9 +79,24 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Install trustedsigning CLI extension
+# Step 1 — Register required resource providers
 ###############################################################################
-info "Step 1: Checking trustedsigning CLI extension..."
+info "Step 1: Registering required Azure resource providers..."
+for _rp in Microsoft.CodeSigning; do
+    _state=$(az provider show --namespace "$_rp" --query "registrationState" -o tsv 2>/dev/null || echo "NotRegistered")
+    if [[ "$_state" == "Registered" ]]; then
+        info "  $_rp is already registered."
+    else
+        info "  Registering $_rp..."
+        run az provider register --namespace "$_rp" --wait
+        info "  $_rp registered."
+    fi
+done
+
+###############################################################################
+# Step 2 — Install trustedsigning CLI extension
+###############################################################################
+info "Step 2: Checking trustedsigning CLI extension..."
 if az extension show --name trustedsigning &>/dev/null; then
     info "trustedsigning extension already installed."
 else
@@ -90,9 +105,9 @@ else
 fi
 
 ###############################################################################
-# Step 2 — Create resource group
+# Step 3 — Create resource group
 ###############################################################################
-info "Step 2: Ensuring resource group '$TS_RG' exists..."
+info "Step 3: Ensuring resource group '$TS_RG' exists..."
 if az group show --name "$TS_RG" &>/dev/null; then
     info "Resource group '$TS_RG' already exists — skipping."
 else
@@ -103,9 +118,9 @@ else
 fi
 
 ###############################################################################
-# Step 3 — Create Trusted Signing account
+# Step 4 — Create Trusted Signing account
 ###############################################################################
-info "Step 3: Creating Trusted Signing account '$TS_ACCOUNT_NAME'..."
+info "Step 4: Creating Trusted Signing account '$TS_ACCOUNT_NAME'..."
 if az trustedsigning show \
     --name "$TS_ACCOUNT_NAME" \
     --resource-group "$TS_RG" &>/dev/null; then
@@ -125,9 +140,9 @@ TS_ACCOUNT_ID=$(az trustedsigning show \
     --query id -o tsv)
 
 ###############################################################################
-# Step 4 — Create Private Trust certificate profile (signing identity)
+# Step 5 — Create Private Trust certificate profile (signing identity)
 ###############################################################################
-info "Step 4: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
+info "Step 5: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
 if az trustedsigning certificate-profile show \
     --account-name "$TS_ACCOUNT_NAME" \
     --resource-group "$TS_RG" \
@@ -150,9 +165,9 @@ else
 fi
 
 ###############################################################################
-# Step 5 — Assign RBAC roles to the current signed-in user
+# Step 6 — Assign RBAC roles to the current signed-in user
 ###############################################################################
-info "Step 5: Assigning RBAC roles to current user..."
+info "Step 6: Assigning RBAC roles to current user..."
 
 CURRENT_USER_ID=$(az ad signed-in-user show --query id -o tsv)
 info "Current user object ID: $CURRENT_USER_ID"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -79,27 +79,9 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Log out and log back in to ensure the correct subscription
+# Step 1 — Install trustedsigning CLI extension
 ###############################################################################
-info "Step 1: Logging out of Azure CLI to ensure a clean session..."
-az logout --verbose 2>/dev/null || true
-info "Logging in to Azure CLI..."
-az login
-if ! az account show --query id -o tsv &>/dev/null; then
-    error "No active Azure CLI session. Authenticate first with one of:"
-    error "  az login                                  (interactive)"
-    error "  az login --service-principal ...          (service principal)"
-    error "  az login --identity                       (managed identity)"
-    exit 1
-fi
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-SUBSCRIPTION=$(az account show --query name -o tsv)
-info "Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
-
-###############################################################################
-# Step 2 — Install trustedsigning CLI extension
-###############################################################################
-info "Step 2: Checking trustedsigning CLI extension..."
+info "Step 1: Checking trustedsigning CLI extension..."
 if az extension show --name trustedsigning &>/dev/null; then
     info "trustedsigning extension already installed."
 else
@@ -108,9 +90,9 @@ else
 fi
 
 ###############################################################################
-# Step 3 — Create resource group
+# Step 2 — Create resource group
 ###############################################################################
-info "Step 3: Ensuring resource group '$TS_RG' exists..."
+info "Step 2: Ensuring resource group '$TS_RG' exists..."
 if az group show --name "$TS_RG" &>/dev/null; then
     info "Resource group '$TS_RG' already exists — skipping."
 else
@@ -121,9 +103,9 @@ else
 fi
 
 ###############################################################################
-# Step 4 — Create Trusted Signing account
+# Step 3 — Create Trusted Signing account
 ###############################################################################
-info "Step 4: Creating Trusted Signing account '$TS_ACCOUNT_NAME'..."
+info "Step 3: Creating Trusted Signing account '$TS_ACCOUNT_NAME'..."
 if az trustedsigning show \
     --name "$TS_ACCOUNT_NAME" \
     --resource-group "$TS_RG" &>/dev/null; then
@@ -143,9 +125,9 @@ TS_ACCOUNT_ID=$(az trustedsigning show \
     --query id -o tsv)
 
 ###############################################################################
-# Step 5 — Create Private Trust certificate profile (signing identity)
+# Step 4 — Create Private Trust certificate profile (signing identity)
 ###############################################################################
-info "Step 5: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
+info "Step 4: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
 if az trustedsigning certificate-profile show \
     --account-name "$TS_ACCOUNT_NAME" \
     --resource-group "$TS_RG" \
@@ -168,9 +150,9 @@ else
 fi
 
 ###############################################################################
-# Step 6 — Assign RBAC roles to the current signed-in user
+# Step 5 — Assign RBAC roles to the current signed-in user
 ###############################################################################
-info "Step 6: Assigning RBAC roles to current user..."
+info "Step 5: Assigning RBAC roles to current user..."
 
 CURRENT_USER_ID=$(az ad signed-in-user show --query id -o tsv)
 info "Current user object ID: $CURRENT_USER_ID"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -148,22 +148,51 @@ info "Step 5: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
 # Preflight: a Completed identity validation must exist on the account before
 # the profile can provision successfully. The ARM create call returns 200/202
 # even without one, but the profile silently ends up in a Failed state.
-info "  Checking for a Completed identity validation on '$TS_ACCOUNT_NAME'..."
+info "  Checking for identity validations on '$TS_ACCOUNT_NAME'..."
 _sub_id=$(az account show --query id -o tsv)
-_iv_count=$(az rest \
+_iv_raw=$(az rest \
     --method GET \
     --url "https://management.azure.com/subscriptions/${_sub_id}/resourceGroups/${TS_RG}/providers/Microsoft.CodeSigning/codeSigningAccounts/${TS_ACCOUNT_NAME}/identityValidations?api-version=2024-09-30-preview" \
-    --query "length(value[?properties.status=='Completed'])" \
-    -o tsv 2>/dev/null || echo "0")
-if [[ "${_iv_count:-0}" -lt 1 ]]; then
-    error "No Completed identity validation found on account '$TS_ACCOUNT_NAME'."
-    error "Certificate profile provisioning will fail silently without one."
-    error "Create an identity validation in the Azure Portal first:"
-    error "  Portal → Trusted Signing → $TS_ACCOUNT_NAME → Identity validation → + Add"
-    error "Wait until its status is 'Completed', then re-run this script."
-    exit 1
+    -o json 2>&1)
+_iv_rc=$?
+
+if [[ $_iv_rc -ne 0 ]]; then
+    # The API call itself failed (endpoint unavailable, permission issue, etc.)
+    # Warn and ask the user to confirm before proceeding.
+    warn "Could not query identity validations (API error): $_iv_raw"
+    warn "Cannot automatically verify that an identity validation exists."
+    warn "A Completed identity validation is required for the profile to provision."
+    warn "Portal → Trusted Signing → $TS_ACCOUNT_NAME → Identity validation"
+    read -rp "Do you have a Completed identity validation on the account? [y/N] " _iv_confirm
+    if [[ ! "${_iv_confirm,,}" =~ ^y ]]; then
+        error "Aborting. Create an identity validation in the Portal and re-run."
+        exit 1
+    fi
+else
+    # API call succeeded — inspect the response.
+    # Show what was found so it is easy to diagnose status mismatches.
+    _iv_statuses=$(echo "$_iv_raw" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(', '.join(v.get('properties', {}).get('status', '?') for v in d.get('value', [])) or 'none')
+" 2>/dev/null || echo "unknown")
+    _iv_count=$(echo "$_iv_raw" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+vals = d.get('value', [])
+completed = [v for v in vals if v.get('properties', {}).get('status', '').lower() in ('completed', 'verified', 'active')]
+print(len(completed))
+" 2>/dev/null || echo "0")
+
+    if [[ "${_iv_count:-0}" -lt 1 ]]; then
+        error "No identity validation with a passing status found on '$TS_ACCOUNT_NAME'."
+        error "Statuses found: ${_iv_statuses:-none}"
+        error "A Completed identity validation is required before the profile can provision."
+        error "Portal → Trusted Signing → $TS_ACCOUNT_NAME → Identity validation → + Add"
+        exit 1
+    fi
+    info "  Identity validation verified (statuses: ${_iv_statuses})."
 fi
-info "  Identity validation verified."
 
 if az trustedsigning certificate-profile show \
     --account-name "$TS_ACCOUNT_NAME" \

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -57,6 +57,7 @@ run() {
         rm -f "$_err"
         return $_rc
     fi
+    [[ -s "$_err" ]] && warn "$(cat "$_err")"
     rm -f "$_err"
 }
 
@@ -143,6 +144,27 @@ TS_ACCOUNT_ID=$(az trustedsigning show \
 # Step 5 — Create Private Trust certificate profile (signing identity)
 ###############################################################################
 info "Step 5: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
+
+# Preflight: a Completed identity validation must exist on the account before
+# the profile can provision successfully. The ARM create call returns 200/202
+# even without one, but the profile silently ends up in a Failed state.
+info "  Checking for a Completed identity validation on '$TS_ACCOUNT_NAME'..."
+_sub_id=$(az account show --query id -o tsv)
+_iv_count=$(az rest \
+    --method GET \
+    --url "https://management.azure.com/subscriptions/${_sub_id}/resourceGroups/${TS_RG}/providers/Microsoft.CodeSigning/codeSigningAccounts/${TS_ACCOUNT_NAME}/identityValidations?api-version=2024-09-30-preview" \
+    --query "length(value[?properties.status=='Completed'])" \
+    -o tsv 2>/dev/null || echo "0")
+if [[ "${_iv_count:-0}" -lt 1 ]]; then
+    error "No Completed identity validation found on account '$TS_ACCOUNT_NAME'."
+    error "Certificate profile provisioning will fail silently without one."
+    error "Create an identity validation in the Azure Portal first:"
+    error "  Portal → Trusted Signing → $TS_ACCOUNT_NAME → Identity validation → + Add"
+    error "Wait until its status is 'Completed', then re-run this script."
+    exit 1
+fi
+info "  Identity validation verified."
+
 if az trustedsigning certificate-profile show \
     --account-name "$TS_ACCOUNT_NAME" \
     --resource-group "$TS_RG" \
@@ -161,6 +183,33 @@ else
         --state "$TS_STATE" \
         --country "$TS_COUNTRY" \
         --include-street-address false
+
+    # Poll until Active — the create is async; a provisioning failure would
+    # otherwise go unnoticed because the CLI exits 0 on HTTP 202 Accepted.
+    info "  Waiting for certificate profile to become Active (timeout: 5 min)..."
+    _deadline=$(( $(date +%s) + 300 ))
+    while true; do
+        _status=$(az trustedsigning certificate-profile show \
+            --account-name "$TS_ACCOUNT_NAME" \
+            --resource-group "$TS_RG" \
+            --profile-name "$TS_CERT_PROFILE" \
+            --query "properties.status" -o tsv 2>/dev/null || echo "Unknown")
+        if [[ "$_status" == "Active" ]]; then
+            info "  Certificate profile is Active."
+            break
+        elif [[ "$_status" == "Failed" || "$_status" == "Disabled" || "$_status" == "Canceled" ]]; then
+            error "Certificate profile entered '$_status' state."
+            error "Verify that the identity validation on the account is 'Completed',"
+            error "then delete the failed profile and re-run this script."
+            exit 1
+        elif [[ $(date +%s) -gt $_deadline ]]; then
+            warn "Timed out waiting for Active status (current: '$_status')."
+            warn "Check the Azure Portal for the profile status before signing."
+            break
+        fi
+        info "  Status: '$_status' — retrying in 15 s..."
+        sleep 15
+    done
     info "Certificate profile '$TS_CERT_PROFILE' created."
 fi
 

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -170,6 +170,7 @@ else
             --resource-group "$TS_RG" \
             --profile-name "$TS_CERT_PROFILE" \
             --query "properties.status" -o tsv 2>/dev/null || echo "Unknown")
+        _status="${_status//[$'\t\r\n ']/}"  # strip whitespace/newlines from tsv output
         if [[ "$_status" == "Active" ]]; then
             info "  Certificate profile is Active."
             break

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# setup-trusted-signing.sh
+#
+# Creates an Azure Trusted Signing account, a Private Trust certificate profile,
+# and assigns the required RBAC roles to the current user.
+#
+# What this script does:
+#   1. Verify Azure login
+#   2. Install the trustedsigning CLI extension if missing
+#   3. Create resource group (if it doesn't exist)
+#   4. Create Trusted Signing account
+#   5. Create a Private Trust certificate profile (signing identity)
+#   6. Assign RBAC roles to the current signed-in user:
+#        - Artifact Signing Certificate Profile Signer  (for signing)
+#        - Artifact Signing Identity Verifier           (for verification)
+#
+# Usage:
+#   chmod +x setup-trusted-signing.sh
+#   ./setup-trusted-signing.sh
+#
+# Required environment variables:
+#   TS_ACCOUNT_NAME  - Trusted Signing account name (e.g. sig-tsm-demo)
+#   TS_RG            - Resource group for the account
+#   TS_LOCATION      - Azure region (e.g. westus2)
+#   TS_CERT_PROFILE  - Certificate profile name (e.g. cert-tsm-demo)
+#
+# Optional environment variables (subject DN fields):
+#   TS_COMMON_NAME   - CN field (default: microsoft.onmicrosoft.com)
+#   TS_ORGANIZATION  - O field  (default: microsoft.onmicrosoft.com)
+#   TS_ORG_UNIT      - OU field (default: Cloud Native Security and Registries)
+#   TS_CITY          - L field  (default: Redmond)
+#   TS_STATE         - S field  (default: Washington)
+#   TS_COUNTRY       - C field  (default: US)
+
+set -euo pipefail
+
+###############################################################################
+# Colors / helpers
+###############################################################################
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+cmd_log() { echo -e "${CYAN}[CMD]${NC} $*"; }
+
+run() {
+    cmd_log "$*"
+    local _err; _err=$(mktemp)
+    if ! "$@" 2>"$_err"; then
+        local _rc=$?
+        [[ -s "$_err" ]] && error "$(cat "$_err")"
+        rm -f "$_err"
+        return $_rc
+    fi
+    rm -f "$_err"
+}
+
+###############################################################################
+# Load shared defaults (override by exporting before running)
+###############################################################################
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=defaults.sh
+source "${SCRIPT_DIR}/defaults.sh"
+
+###############################################################################
+# Validate required variables
+###############################################################################
+REQUIRED_VARS=(TS_ACCOUNT_NAME TS_RG TS_LOCATION TS_CERT_PROFILE)
+for var in "${REQUIRED_VARS[@]}"; do
+    if [[ -z "${!var:-}" ]]; then
+        error "Required environment variable \$$var is not set."
+        exit 1
+    fi
+done
+
+###############################################################################
+# Step 1 — Verify Azure login
+###############################################################################
+info "Step 1: Verifying Azure login..."
+if ! az account show --query id -o tsv &>/dev/null; then
+    warn "Not logged in. Running az login..."
+    run az login
+fi
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+SUBSCRIPTION=$(az account show --query name -o tsv)
+info "Using subscription: $SUBSCRIPTION ($SUBSCRIPTION_ID)"
+
+###############################################################################
+# Step 2 — Install trustedsigning CLI extension
+###############################################################################
+info "Step 2: Checking trustedsigning CLI extension..."
+if az extension show --name trustedsigning &>/dev/null; then
+    info "trustedsigning extension already installed."
+else
+    info "Installing trustedsigning extension..."
+    run az extension add --name trustedsigning
+fi
+
+###############################################################################
+# Step 3 — Create resource group
+###############################################################################
+info "Step 3: Ensuring resource group '$TS_RG' exists..."
+if az group show --name "$TS_RG" &>/dev/null; then
+    info "Resource group '$TS_RG' already exists — skipping."
+else
+    run az group create \
+        --name "$TS_RG" \
+        --location "$TS_LOCATION"
+    info "Resource group '$TS_RG' created."
+fi
+
+###############################################################################
+# Step 4 — Create Trusted Signing account
+###############################################################################
+info "Step 4: Creating Trusted Signing account '$TS_ACCOUNT_NAME'..."
+if az trustedsigning show \
+    --name "$TS_ACCOUNT_NAME" \
+    --resource-group "$TS_RG" &>/dev/null; then
+    info "Trusted Signing account '$TS_ACCOUNT_NAME' already exists — skipping."
+else
+    run az trustedsigning create \
+        --name "$TS_ACCOUNT_NAME" \
+        --resource-group "$TS_RG" \
+        --location "$TS_LOCATION" \
+        --sku "$TS_SKU"
+    info "Trusted Signing account '$TS_ACCOUNT_NAME' created."
+fi
+
+TS_ACCOUNT_ID=$(az trustedsigning show \
+    --name "$TS_ACCOUNT_NAME" \
+    --resource-group "$TS_RG" \
+    --query id -o tsv)
+
+###############################################################################
+# Step 5 — Create Private Trust certificate profile (signing identity)
+###############################################################################
+info "Step 5: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
+if az trustedsigning certificate-profile show \
+    --account-name "$TS_ACCOUNT_NAME" \
+    --resource-group "$TS_RG" \
+    --profile-name "$TS_CERT_PROFILE" &>/dev/null; then
+    info "Certificate profile '$TS_CERT_PROFILE' already exists — skipping."
+else
+    run az trustedsigning certificate-profile create \
+        --account-name "$TS_ACCOUNT_NAME" \
+        --resource-group "$TS_RG" \
+        --profile-name "$TS_CERT_PROFILE" \
+        --profile-type PrivateTrust \
+        --common-name "$TS_COMMON_NAME" \
+        --organization "$TS_ORGANIZATION" \
+        --organization-unit "$TS_ORG_UNIT" \
+        --city "$TS_CITY" \
+        --state "$TS_STATE" \
+        --country "$TS_COUNTRY" \
+        --include-street-address false
+    info "Certificate profile '$TS_CERT_PROFILE' created."
+fi
+
+###############################################################################
+# Step 6 — Assign RBAC roles to the current signed-in user
+###############################################################################
+info "Step 6: Assigning RBAC roles to current user..."
+
+CURRENT_USER_ID=$(az ad signed-in-user show --query id -o tsv)
+info "Current user object ID: $CURRENT_USER_ID"
+
+_assign_role() {
+    local role="$1"
+    local scope="$2"
+    local existing
+    existing=$(az role assignment list \
+        --assignee "$CURRENT_USER_ID" \
+        --role "$role" \
+        --scope "$scope" \
+        --query "[0].id" -o tsv 2>/dev/null || true)
+    if [[ -n "$existing" ]]; then
+        info "  Role '$role' already assigned — skipping."
+    else
+        run az role assignment create \
+            --assignee "$CURRENT_USER_ID" \
+            --role "$role" \
+            --scope "$scope"
+        info "  Role '$role' assigned."
+    fi
+}
+
+# Signing: allows the user to sign artifacts using this certificate profile
+_assign_role \
+    "Artifact Signing Certificate Profile Signer" \
+    "$TS_ACCOUNT_ID"
+
+# Verification: allows the user (and Ratify) to verify signatures
+_assign_role \
+    "Artifact Signing Identity Verifier" \
+    "$TS_ACCOUNT_ID"
+
+###############################################################################
+# Summary
+###############################################################################
+echo
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}  Trusted Signing setup complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo
+echo "  Account:         $TS_ACCOUNT_NAME ($TS_RG)"
+echo "  Endpoint:        https://${TS_LOCATION}.codesigning.azure.net/"
+echo "  Cert Profile:    $TS_CERT_PROFILE (PrivateTrust)"
+echo "  Subject DN:"
+echo "    CN=$TS_COMMON_NAME"
+echo "    O=$TS_ORGANIZATION"
+echo "    OU=$TS_ORG_UNIT"
+echo "    L=$TS_CITY, S=$TS_STATE, C=$TS_COUNTRY"
+echo
+echo "Next steps:"
+echo "  1. Copy images to ACR:  ./setup-acr.sh"
+echo "  2. Sign the image:      notation sign --plugin azure-artifactsigning \\"
+echo "       --plugin-config accountName=$TS_ACCOUNT_NAME \\"
+echo "       --plugin-config baseUrl=https://${TS_LOCATION}.codesigning.azure.net/ \\"
+echo "       --plugin-config certProfile=$TS_CERT_PROFILE \\"
+echo "       --id $TS_CERT_PROFILE \\"
+echo "       <acr>/nginx:1.29-alpine-signed"
+echo "  3. Set up AKS cluster:  ./setup-aks.sh"
+echo

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -19,18 +19,13 @@
 #   ./setup-trusted-signing.sh
 #
 # Required environment variables:
-#   TS_ACCOUNT_NAME  - Trusted Signing account name (e.g. sig-tsm-demo)
-#   TS_RG            - Resource group for the account
-#   TS_LOCATION      - Azure region (e.g. westus2)
-#   TS_CERT_PROFILE  - Certificate profile name (e.g. cert-tsm-demo)
-#
-# Optional environment variables (subject DN fields):
-#   TS_COMMON_NAME   - CN field (default: microsoft.onmicrosoft.com)
-#   TS_ORGANIZATION  - O field  (default: microsoft.onmicrosoft.com)
-#   TS_ORG_UNIT      - OU field (default: Cloud Native Security and Registries)
-#   TS_CITY          - L field  (default: Redmond)
-#   TS_STATE         - S field  (default: Washington)
-#   TS_COUNTRY       - C field  (default: US)
+#   TS_ACCOUNT_NAME          - Trusted Signing account name (e.g. sig-tsm-demo)
+#   TS_RG                    - Resource group for the account
+#   TS_LOCATION              - Azure region (e.g. westus2)
+#   TS_CERT_PROFILE          - Certificate profile name (e.g. cert-tsm-demo)
+#   TS_IDENTITY_VALIDATION_ID - GUID of the Completed identity validation on the
+#                              account. Find it in the Portal:
+#                              Trusted Signing → <account> → Identity validation
 
 set -euo pipefail
 
@@ -71,7 +66,7 @@ source "${SCRIPT_DIR}/defaults.sh"
 ###############################################################################
 # Validate required variables
 ###############################################################################
-REQUIRED_VARS=(TS_ACCOUNT_NAME TS_RG TS_LOCATION TS_CERT_PROFILE)
+REQUIRED_VARS=(TS_ACCOUNT_NAME TS_RG TS_LOCATION TS_CERT_PROFILE TS_IDENTITY_VALIDATION_ID)
 for var in "${REQUIRED_VARS[@]}"; do
     if [[ -z "${!var:-}" ]]; then
         error "Required environment variable \$$var is not set."
@@ -159,12 +154,10 @@ else
         --resource-group "$TS_RG" \
         --profile-name "$TS_CERT_PROFILE" \
         --profile-type PrivateTrust \
-        --common-name "$TS_COMMON_NAME" \
-        --organization "$TS_ORGANIZATION" \
-        --organization-unit "$TS_ORG_UNIT" \
-        --city "$TS_CITY" \
-        --state "$TS_STATE" \
-        --country "$TS_COUNTRY" \
+        --identity-validation-id "$TS_IDENTITY_VALIDATION_ID" \
+        --include-city true \
+        --include-state true \
+        --include-country true \
         --include-street-address false
 
     # Poll until Active — the create is async; a provisioning failure would
@@ -245,11 +238,7 @@ echo
 echo "  Account:         $TS_ACCOUNT_NAME ($TS_RG)"
 echo "  Endpoint:        https://${TS_LOCATION}.codesigning.azure.net/"
 echo "  Cert Profile:    $TS_CERT_PROFILE (PrivateTrust)"
-echo "  Subject DN:"
-echo "    CN=$TS_COMMON_NAME"
-echo "    O=$TS_ORGANIZATION"
-echo "    OU=$TS_ORG_UNIT"
-echo "    L=$TS_CITY, S=$TS_STATE, C=$TS_COUNTRY"
+echo "  Identity Val ID: $TS_IDENTITY_VALIDATION_ID"
 echo
 echo "Next steps:"
 echo "  1. Copy images to ACR:  ./setup-acr.sh"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -83,8 +83,11 @@ done
 ###############################################################################
 info "Step 1: Verifying Azure login..."
 if ! az account show --query id -o tsv &>/dev/null; then
-    warn "Not logged in. Running az login..."
-    run az login
+    error "No active Azure CLI session. Authenticate first with one of:"
+    error "  az login                                  (interactive)"
+    error "  az login --service-principal ...          (service principal)"
+    error "  az login --identity                       (managed identity)"
+    exit 1
 fi
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SUBSCRIPTION=$(az account show --query name -o tsv)

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -144,55 +144,9 @@ TS_ACCOUNT_ID=$(az trustedsigning show \
 # Step 5 — Create Private Trust certificate profile (signing identity)
 ###############################################################################
 info "Step 5: Creating certificate profile '$TS_CERT_PROFILE' (PrivateTrust)..."
-
-# Preflight: a Completed identity validation must exist on the account before
-# the profile can provision successfully. The ARM create call returns 200/202
-# even without one, but the profile silently ends up in a Failed state.
-info "  Checking for identity validations on '$TS_ACCOUNT_NAME'..."
-_sub_id=$(az account show --query id -o tsv)
-_iv_raw=$(az rest \
-    --method GET \
-    --url "https://management.azure.com/subscriptions/${_sub_id}/resourceGroups/${TS_RG}/providers/Microsoft.CodeSigning/codeSigningAccounts/${TS_ACCOUNT_NAME}/identityValidations?api-version=2024-09-30-preview" \
-    -o json 2>&1)
-_iv_rc=$?
-
-if [[ $_iv_rc -ne 0 ]]; then
-    # The API call itself failed (endpoint unavailable, permission issue, etc.)
-    # Warn and ask the user to confirm before proceeding.
-    warn "Could not query identity validations (API error): $_iv_raw"
-    warn "Cannot automatically verify that an identity validation exists."
-    warn "A Completed identity validation is required for the profile to provision."
-    warn "Portal → Trusted Signing → $TS_ACCOUNT_NAME → Identity validation"
-    read -rp "Do you have a Completed identity validation on the account? [y/N] " _iv_confirm
-    if [[ ! "${_iv_confirm,,}" =~ ^y ]]; then
-        error "Aborting. Create an identity validation in the Portal and re-run."
-        exit 1
-    fi
-else
-    # API call succeeded — inspect the response.
-    # Show what was found so it is easy to diagnose status mismatches.
-    _iv_statuses=$(echo "$_iv_raw" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-print(', '.join(v.get('properties', {}).get('status', '?') for v in d.get('value', [])) or 'none')
-" 2>/dev/null || echo "unknown")
-    _iv_count=$(echo "$_iv_raw" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-vals = d.get('value', [])
-completed = [v for v in vals if v.get('properties', {}).get('status', '').lower() in ('completed', 'verified', 'active')]
-print(len(completed))
-" 2>/dev/null || echo "0")
-
-    if [[ "${_iv_count:-0}" -lt 1 ]]; then
-        error "No identity validation with a passing status found on '$TS_ACCOUNT_NAME'."
-        error "Statuses found: ${_iv_statuses:-none}"
-        error "A Completed identity validation is required before the profile can provision."
-        error "Portal → Trusted Signing → $TS_ACCOUNT_NAME → Identity validation → + Add"
-        exit 1
-    fi
-    info "  Identity validation verified (statuses: ${_iv_statuses})."
-fi
+warn "NOTE: A Completed identity validation must exist on the account before"
+warn "      running this script. Verify in the Portal:"
+warn "      Trusted Signing → $TS_ACCOUNT_NAME → Identity validation"
 
 if az trustedsigning certificate-profile show \
     --account-name "$TS_ACCOUNT_NAME" \

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/setup-trusted-signing.sh
@@ -79,9 +79,12 @@ for var in "${REQUIRED_VARS[@]}"; do
 done
 
 ###############################################################################
-# Step 1 — Verify Azure login
+# Step 1 — Log out and log back in to ensure the correct subscription
 ###############################################################################
-info "Step 1: Verifying Azure login..."
+info "Step 1: Logging out of Azure CLI to ensure a clean session..."
+az logout --verbose 2>/dev/null || true
+info "Logging in to Azure CLI..."
+az login
 if ! az account show --query id -o tsv &>/dev/null; then
     error "No active Azure CLI session. Authenticate first with one of:"
     error "  az login                                  (interactive)"

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
@@ -3,7 +3,7 @@
     "trustPolicies": [
         {
             "name": "demoPolicy",
-            "registryScopes": [ "acrtsmpremiumsku.azurecr.io/nginx" ],
+            "registryScopes": [ "acrtsmkubeconeu2026demo.azurecr.io/nginx" ],
             "signatureVerification": {
                 "level" : "strict"
             },

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
@@ -9,7 +9,7 @@
             },
             "trustStores": [ "ca:kubeconDemoSigningRootCerts", "tsa:kubeconDemoTsaRootCerts" ],
             "trustedIdentities": [
-                "x509.subject: CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052"
+                "x509.subject: CN=toddysmlive.onmicrosoft.com,OU=Cloud Native Security and Registries,O=toddysmlive.onmicrosoft.com,L=Redmond,ST=Washington,C=US"
             ]
         }
     ]

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
@@ -9,7 +9,7 @@
             },
             "trustStores": [ "ca:kubeconDemoSigningRootCerts", "tsa:kubeconDemoTsaRootCerts" ],
             "trustedIdentities": [
-                "x509.subject: CN=microsoft.onmicrosoft.com, O=microsoft.onmicrosoft.com, OU=Cloud Native Security and Registries, L=Redmond, S=Washington, C=US"
+                "x509.subject: CN=toddysmlive.onmicrosoft.com, O=toddysmlive.onmicrosoft.com, OU=Cloud Native Security and Registries, STREET=1 Microsoft Way, L=Redmond, S=Washington, C=US, PC=98052"
             ]
         }
     ]

--- a/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
+++ b/demos/kubecon-eu-2026/artifact-signing/trusted-signing/trustpolicy.json
@@ -3,7 +3,7 @@
     "trustPolicies": [
         {
             "name": "demoPolicy",
-            "registryScopes": [ "acrtsmpremiumsku.azurecr.io/python" ],
+            "registryScopes": [ "acrtsmpremiumsku.azurecr.io/nginx" ],
             "signatureVerification": {
                 "level" : "strict"
             },


### PR DESCRIPTION
## Summary

Adds two Kubernetes manifest files to the `trusted-signing/` folder to complete the KubeCon EU 2026 artifact-signing demo flow.

## Files added

### `nginx-signed-demo.yaml`
Deploys a **signed** NGINX image (`acrtsmpremiumsku.azurecr.io/nginx:1.29-alpine-signed`) and exposes it via an Azure Load Balancer. Includes:
- **ConfigMap** with a custom demo HTML page that visualises the signature verification result
- **Deployment** (1 replica) mounting the ConfigMap at `/usr/share/nginx/html`
- **Service** (`type: LoadBalancer`) on port 80 for public internet access

Expected outcome: admission **allowed** — Gatekeeper + Ratify verifies a valid Notation signature.

### `nginx-unsigned-demo.yaml`
Deploys an **unsigned** NGINX image (`acrtsmpremiumsku.azurecr.io/nginx:1.28-alpine-unsigned`) with no signature.

Expected outcome: admission **rejected** by Gatekeeper + Ratify with a signature verification failure message.

## Demo flow

```bash
# 1. Deploy the signed image — should SUCCEED
kubectl apply -f nginx-signed-demo.yaml

# Wait for external IP
kubectl get svc nginx-signed-demo -w

# 2. Try to deploy the unsigned image — should be REJECTED
kubectl apply -f nginx-unsigned-demo.yaml
```

## Pending

The following file has local changes that will be included in a subsequent commit on this branch:

- **`demo-trusted-signing.sh`** — cleanup step added for the Notation trust policy on macOS (`~/Library/Application Support/notation/trustpolicy.json`)
